### PR TITLE
Create a complete CartonInfo struct and populate it from the v1 format

### DIFF
--- a/source/carton-runner-interface/src/runner.rs
+++ b/source/carton-runner-interface/src/runner.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use crate::{
     client::Client,
@@ -57,7 +57,7 @@ impl Runner {
         Ok(Self { client })
     }
 
-    pub async fn load(&self, _fs: impl lunchbox::ReadableFileSystem) {
+    pub async fn load<T: lunchbox::ReadableFileSystem>(&self, _fs: &Arc<T>) {
         // match client
         //     .do_rpc(RPCRequestData::Load {
         //         path,

--- a/source/carton/src/format/mod.rs
+++ b/source/carton/src/format/mod.rs
@@ -1,1 +1,1 @@
-pub mod v1;
+pub(crate) mod v1;

--- a/source/carton/src/format/v1/carton_toml.rs
+++ b/source/carton/src/format/v1/carton_toml.rs
@@ -12,38 +12,38 @@ pub struct CartonToml {
     spec_version: u64,
 
     /// The name of the model
-    pub model_name: Option<String>,
+    pub(crate) model_name: Option<String>,
 
     /// The model description
-    pub model_description: Option<String>,
+    pub(crate) model_description: Option<String>,
 
     /// A list of platforms this model supports
     /// If empty, all platforms are okay
     /// These are target triples
-    required_platforms: Option<Vec<Triple>>,
+    pub(crate) required_platforms: Option<Vec<Triple>>,
 
     /// A list of inputs for the model
     /// Can be empty
-    pub input: Option<Vec<TensorSpec>>,
+    pub(crate) input: Option<Vec<TensorSpec>>,
 
     /// A list of outputs for the model
     /// Can be empty
-    pub output: Option<Vec<TensorSpec>>,
+    pub(crate) output: Option<Vec<TensorSpec>>,
 
     /// Test data
     /// Can be empty
-    self_test: Option<Vec<SelfTest>>,
+    pub(crate) self_test: Option<Vec<SelfTest>>,
 
     /// Examples
     /// Can be empty
-    example: Option<Vec<Example>>,
+    pub(crate) example: Option<Vec<Example>>,
 
     /// Information about the runner to use
-    pub runner: RunnerInfo,
+    pub(crate) runner: RunnerInfo,
 }
 
 #[derive(Debug, PartialEq)]
-struct Triple(target_lexicon::Triple);
+pub(crate) struct Triple(pub(crate) target_lexicon::Triple);
 
 impl Serialize for Triple {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -91,12 +91,12 @@ pub enum RunnerOpt {
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 #[non_exhaustive]
 pub struct SelfTest {
-    name: Option<String>,
-    description: Option<String>,
-    inputs: HashMap<String, TensorReference>,
+    pub(crate) name: Option<String>,
+    pub(crate) description: Option<String>,
+    pub(crate) inputs: HashMap<String, TensorReference>,
 
     // Can be empty
-    expected_out: Option<HashMap<String, TensorReference>>,
+    pub(crate) expected_out: Option<HashMap<String, TensorReference>>,
 }
 
 struct RequiredPrefixVisitor<'a, T> {
@@ -136,7 +136,7 @@ impl<'a, 'de, T: From<String>> Visitor<'de> for RequiredPrefixVisitor<'a, T> {
 /// References a tensor in @tensor_data
 /// Must be a string that starts with `@tensor_data/`
 #[derive(Debug, PartialEq)]
-pub struct TensorReference(String);
+pub struct TensorReference(pub(crate) String);
 
 impl Serialize for TensorReference {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -168,10 +168,10 @@ impl From<String> for TensorReference {
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 #[non_exhaustive]
 pub struct Example {
-    name: Option<String>,
-    description: Option<String>,
-    inputs: HashMap<String, TensorOrMiscReference>,
-    sample_out: HashMap<String, TensorOrMiscReference>,
+    pub(crate) name: Option<String>,
+    pub(crate) description: Option<String>,
+    pub(crate) inputs: HashMap<String, TensorOrMiscReference>,
+    pub(crate) sample_out: HashMap<String, TensorOrMiscReference>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
@@ -184,7 +184,7 @@ pub enum TensorOrMiscReference {
 /// References a file in @misc
 /// Must be a string that starts with `@misc/`
 #[derive(Debug, PartialEq)]
-pub struct MiscFileReference(String);
+pub struct MiscFileReference(pub(crate) String);
 
 impl Serialize for MiscFileReference {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -216,19 +216,19 @@ impl From<String> for MiscFileReference {
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 #[non_exhaustive]
 pub struct TensorSpec {
-    name: String,
+    pub(crate) name: String,
 
     /// The datatype
-    dtype: DataType,
+    pub(crate) dtype: DataType,
 
     /// Tensor shape
-    shape: Shape,
+    pub(crate) shape: Shape,
 
     /// Optional description
-    description: Option<String>,
+    pub(crate) description: Option<String>,
 
     /// Optional internal name
-    internal_name: Option<String>,
+    pub(crate) internal_name: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]

--- a/source/carton/src/format/v1/load.rs
+++ b/source/carton/src/format/v1/load.rs
@@ -1,0 +1,302 @@
+//! Get a CartonInfo struct from a FS
+//! This module does a lot of type conversions to map from the types in the toml file to the ones in
+//! crate::types and crate::info
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use lunchbox::types::{MaybeSend, MaybeSync, ReadableFile};
+use lunchbox::ReadableFileSystem;
+
+use crate::error::Result;
+use crate::info::PossiblyLoaded;
+use crate::types::CartonInfo;
+
+async fn load_tensor_from_fs<T>(fs: &T, path: &str) -> crate::types::Tensor
+where
+    T: ReadableFileSystem,
+    T::FileType: ReadableFile + 'static,
+{
+    let f = fs.open(path).await.unwrap();
+    // Actually read the tensor and return it
+    todo!()
+}
+
+async fn load_misc_from_fs<T>(fs: &T, path: &str) -> crate::info::MiscFile
+where
+    T: ReadableFileSystem,
+    T::FileType: ReadableFile + 'static,
+{
+    Box::new(fs.open(path).await.unwrap())
+}
+
+pub async fn load<T>(fs: &Arc<T>) -> Result<CartonInfo>
+where
+    T: ReadableFileSystem + MaybeSend + MaybeSync + 'static,
+    T::FileType: ReadableFile + 'static,
+{
+    // Load the toml file
+    let toml = fs.read("/carton.toml").await?;
+    let config = crate::format::v1::carton_toml::parse(&toml).await?;
+
+    // Create a CartonInfo struct
+    Ok(CartonInfo {
+        model_name: config.model_name,
+        model_description: config.model_description,
+        required_platforms: convert_opt_vec(config.required_platforms),
+        inputs: convert_opt_vec(config.input),
+        outputs: convert_opt_vec(config.output),
+        self_tests: config.self_test.convert(fs),
+        examples: config.example.convert(fs),
+        runner: config.runner.into(),
+    })
+}
+
+// Type conversions
+trait ConvertFrom<T> {
+    fn from<F>(item: T, fs: &Arc<F>) -> Self
+    where
+        F: ReadableFileSystem + MaybeSend + MaybeSync + 'static,
+        F::FileType: ReadableFile + 'static;
+}
+
+// Something like "into"
+trait ConvertInto<T> {
+    fn convert<F>(self, fs: &Arc<F>) -> T
+    where
+        F: ReadableFileSystem + MaybeSend + MaybeSync + 'static,
+        F::FileType: ReadableFile + 'static;
+}
+
+// Blanket impl
+impl<T, U> ConvertInto<U> for T
+where
+    U: ConvertFrom<T>,
+{
+    fn convert<F>(self, fs: &Arc<F>) -> U
+    where
+        F: ReadableFileSystem + MaybeSend + MaybeSync + 'static,
+        F::FileType: ReadableFile + 'static,
+    {
+        U::from(self, fs)
+    }
+}
+
+impl<T, U> ConvertFrom<Vec<T>> for Vec<U>
+where
+    U: ConvertFrom<T>,
+{
+    fn from<F>(item: Vec<T>, fs: &Arc<F>) -> Self
+    where
+        F: ReadableFileSystem + MaybeSend + MaybeSync + 'static,
+        F::FileType: ReadableFile + 'static,
+    {
+        item.into_iter().map(|v| v.convert(fs)).collect()
+    }
+}
+
+impl<T, U> ConvertFrom<HashMap<String, T>> for HashMap<String, U>
+where
+    U: ConvertFrom<T>,
+{
+    fn from<F>(item: HashMap<String, T>, fs: &Arc<F>) -> Self
+    where
+        F: ReadableFileSystem + MaybeSend + MaybeSync + 'static,
+        F::FileType: ReadableFile + 'static,
+    {
+        item.into_iter().map(|(k, v)| (k, v.convert(fs))).collect()
+    }
+}
+
+impl<T, U> ConvertFrom<Option<T>> for Option<U>
+where
+    U: ConvertFrom<T>,
+{
+    fn from<F>(item: Option<T>, fs: &Arc<F>) -> Self
+    where
+        F: ReadableFileSystem + MaybeSend + MaybeSync + 'static,
+        F::FileType: ReadableFile + 'static,
+    {
+        item.map(|v| v.convert(fs))
+    }
+}
+
+fn convert_vec<T, U>(v: Vec<T>) -> Vec<U>
+where
+    U: From<T>,
+{
+    v.into_iter().map(|v| v.into()).collect()
+}
+
+fn convert_map<T, U>(v: HashMap<String, T>) -> HashMap<String, U>
+where
+    U: From<T>,
+{
+    v.into_iter().map(|(k, v)| (k, v.into())).collect()
+}
+
+fn convert_opt_vec<T, U>(v: Option<Vec<T>>) -> Option<Vec<U>>
+where
+    U: From<T>,
+{
+    v.map(|item| convert_vec(item))
+}
+
+fn convert_opt_map<T, U>(v: Option<HashMap<String, T>>) -> Option<HashMap<String, U>>
+where
+    U: From<T>,
+{
+    v.map(|item| convert_map(item))
+}
+
+impl ConvertFrom<super::carton_toml::TensorReference> for PossiblyLoaded<crate::types::Tensor> {
+    fn from<F>(item: super::carton_toml::TensorReference, fs: &Arc<F>) -> Self
+    where
+        F: ReadableFileSystem + MaybeSend + MaybeSync + 'static,
+        F::FileType: ReadableFile + 'static,
+    {
+        let fs = fs.clone();
+        PossiblyLoaded::from_loader(Box::pin(async move {
+            load_tensor_from_fs(fs.as_ref(), item.0.strip_prefix("@").unwrap()).await
+        }))
+    }
+}
+
+impl ConvertFrom<super::carton_toml::MiscFileReference> for PossiblyLoaded<crate::info::MiscFile> {
+    fn from<F>(item: super::carton_toml::MiscFileReference, fs: &Arc<F>) -> Self
+    where
+        F: ReadableFileSystem + MaybeSend + MaybeSync + 'static,
+        F::FileType: ReadableFile + 'static,
+    {
+        let fs = fs.clone();
+        PossiblyLoaded::from_loader(Box::pin(async move {
+            load_misc_from_fs(fs.as_ref(), item.0.strip_prefix("@").unwrap()).await
+        }))
+    }
+}
+
+impl ConvertFrom<super::carton_toml::TensorOrMiscReference> for crate::info::TensorOrMisc {
+    fn from<F>(item: super::carton_toml::TensorOrMiscReference, fs: &Arc<F>) -> Self
+    where
+        F: ReadableFileSystem + MaybeSend + MaybeSync + 'static,
+        F::FileType: ReadableFile + 'static,
+    {
+        match item {
+            super::carton_toml::TensorOrMiscReference::T(v) => {
+                crate::info::TensorOrMisc::Tensor(v.convert(fs))
+            }
+            super::carton_toml::TensorOrMiscReference::M(v) => {
+                crate::info::TensorOrMisc::Misc(v.convert(fs))
+            }
+        }
+    }
+}
+
+impl ConvertFrom<super::carton_toml::Example> for crate::info::Example {
+    fn from<F>(item: super::carton_toml::Example, fs: &Arc<F>) -> Self
+    where
+        F: ReadableFileSystem + MaybeSend + MaybeSync + 'static,
+        F::FileType: ReadableFile + 'static,
+    {
+        Self {
+            name: item.name,
+            description: item.description,
+            inputs: item.inputs.convert(fs),
+            sample_out: item.sample_out.convert(fs),
+        }
+    }
+}
+
+impl ConvertFrom<super::carton_toml::SelfTest> for crate::info::SelfTest {
+    fn from<F>(item: super::carton_toml::SelfTest, fs: &Arc<F>) -> Self
+    where
+        F: ReadableFileSystem + MaybeSend + MaybeSync + 'static,
+        F::FileType: ReadableFile + 'static,
+    {
+        Self {
+            name: item.name,
+            description: item.description,
+            inputs: item.inputs.convert(fs),
+            expected_out: item.expected_out.convert(fs),
+        }
+    }
+}
+
+impl From<super::carton_toml::Triple> for target_lexicon::Triple {
+    fn from(value: super::carton_toml::Triple) -> Self {
+        value.0
+    }
+}
+
+impl From<super::carton_toml::TensorSpec> for crate::info::TensorSpec {
+    fn from(value: super::carton_toml::TensorSpec) -> Self {
+        Self {
+            name: value.name,
+            dtype: value.dtype.into(),
+            shape: value.shape.into(),
+            description: value.description,
+            internal_name: value.internal_name,
+        }
+    }
+}
+
+impl From<super::carton_toml::RunnerInfo> for crate::info::RunnerInfo {
+    fn from(value: super::carton_toml::RunnerInfo) -> Self {
+        Self {
+            runner_name: value.runner_name,
+            required_framework_version: value.required_framework_version,
+            runner_compat_version: value.runner_compat_version,
+            opts: convert_opt_map(value.opts),
+        }
+    }
+}
+
+impl From<super::carton_toml::Shape> for crate::info::Shape {
+    fn from(value: super::carton_toml::Shape) -> Self {
+        match value {
+            super::carton_toml::Shape::Any => Self::Any,
+            super::carton_toml::Shape::Symbol(v) => Self::Symbol(v),
+            super::carton_toml::Shape::Shape(v) => Self::Shape(convert_vec(v)),
+        }
+    }
+}
+
+impl From<super::carton_toml::Dimension> for crate::info::Dimension {
+    fn from(value: super::carton_toml::Dimension) -> Self {
+        match value {
+            super::carton_toml::Dimension::Value(v) => Self::Value(v),
+            super::carton_toml::Dimension::Symbol(v) => Self::Symbol(v),
+            super::carton_toml::Dimension::Any => Self::Any,
+        }
+    }
+}
+
+impl From<super::carton_toml::DataType> for crate::info::DataType {
+    fn from(value: super::carton_toml::DataType) -> Self {
+        match value {
+            super::carton_toml::DataType::Float32 => Self::Float,
+            super::carton_toml::DataType::Float64 => Self::Double,
+            super::carton_toml::DataType::String => Self::String,
+            super::carton_toml::DataType::Int8 => Self::I8,
+            super::carton_toml::DataType::Int16 => Self::I16,
+            super::carton_toml::DataType::Int32 => Self::I32,
+            super::carton_toml::DataType::Int64 => Self::I64,
+            super::carton_toml::DataType::Uint8 => Self::U8,
+            super::carton_toml::DataType::Uint16 => Self::U16,
+            super::carton_toml::DataType::Uint32 => Self::U32,
+            super::carton_toml::DataType::Uint64 => Self::U64,
+        }
+    }
+}
+
+impl From<super::carton_toml::RunnerOpt> for crate::info::RunnerOpt {
+    fn from(value: super::carton_toml::RunnerOpt) -> Self {
+        match value {
+            super::carton_toml::RunnerOpt::Integer(v) => Self::Integer(v),
+            super::carton_toml::RunnerOpt::Double(v) => Self::Double(v),
+            super::carton_toml::RunnerOpt::String(v) => Self::String(v),
+            super::carton_toml::RunnerOpt::Boolean(v) => Self::Boolean(v),
+            super::carton_toml::RunnerOpt::Date(v) => Self::Date(v),
+        }
+    }
+}

--- a/source/carton/src/format/v1/mod.rs
+++ b/source/carton/src/format/v1/mod.rs
@@ -1,3 +1,5 @@
 //! This module implements v1 of the Carton file format spec
 //! See `docs/specification/format.md` for more details
-pub(crate) mod carton_toml;
+mod carton_toml;
+mod load;
+pub(crate) use load::load;

--- a/source/carton/src/info.rs
+++ b/source/carton/src/info.rs
@@ -1,0 +1,184 @@
+use std::{collections::HashMap, pin::Pin};
+
+use carton_macros::for_each_carton_type;
+use target_lexicon::Triple;
+use tokio::io::AsyncRead;
+
+use crate::types::Tensor;
+
+// Info about a carton
+pub struct CartonInfo {
+    /// The name of the model
+    pub model_name: Option<String>,
+
+    /// The model description
+    pub model_description: Option<String>,
+
+    /// A list of platforms this model supports
+    /// If empty or unspecified, all platforms are okay
+    pub required_platforms: Option<Vec<Triple>>,
+
+    /// A list of inputs for the model
+    /// Can be empty
+    pub inputs: Option<Vec<TensorSpec>>,
+
+    /// A list of outputs for the model
+    /// Can be empty
+    pub outputs: Option<Vec<TensorSpec>>,
+
+    /// Test data
+    /// Can be empty
+    pub self_tests: Option<Vec<SelfTest>>,
+
+    /// Examples
+    /// Can be empty
+    pub examples: Option<Vec<Example>>,
+
+    /// Information about the runner to use
+    pub runner: RunnerInfo,
+}
+
+#[cfg(target_family = "wasm")]
+pub type BoxFuture<'a, T> = Pin<Box<dyn std::future::Future<Output = T> + 'a>>;
+
+#[cfg(not(target_family = "wasm"))]
+pub type BoxFuture<'a, T> = Pin<Box<dyn std::future::Future<Output = T> + Send + 'a>>;
+
+/// Something that is possibly loaded
+pub enum PossiblyLoaded<T> {
+    // Something that can return a T
+    Unloaded(BoxFuture<'static, T>),
+
+    // A T
+    Loaded(T),
+}
+
+impl<T> PossiblyLoaded<T> {
+    pub fn from_value(value: T) -> Self {
+        Self::Loaded(value)
+    }
+
+    pub fn from_loader(loader: BoxFuture<'static, T>) -> Self {
+        Self::Unloaded(loader)
+    }
+
+    pub async fn get(&mut self) -> &T {
+        match self {
+            PossiblyLoaded::Unloaded(fetcher) => {
+                let item = fetcher.await;
+                *self = Self::Loaded(item);
+
+                if let Self::Loaded(item) = self {
+                    item
+                } else {
+                    panic!("PossiblyLoaded was not loaded even though we just loaded it")
+                }
+            }
+            PossiblyLoaded::Loaded(item) => item,
+        }
+    }
+}
+
+impl<T> From<T> for PossiblyLoaded<T> {
+    fn from(value: T) -> Self {
+        Self::Loaded(value)
+    }
+}
+
+pub struct SelfTest {
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub inputs: HashMap<String, PossiblyLoaded<Tensor>>,
+
+    // Can be empty
+    pub expected_out: Option<HashMap<String, PossiblyLoaded<Tensor>>>,
+}
+
+pub struct Example {
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub inputs: HashMap<String, TensorOrMisc>,
+    pub sample_out: HashMap<String, TensorOrMisc>,
+}
+
+/// This isn't ideal, but since it's not on the critical path, it's probably okay
+pub type MiscFile = Box<dyn AsyncRead>;
+
+pub enum TensorOrMisc {
+    Tensor(PossiblyLoaded<Tensor>),
+    Misc(PossiblyLoaded<MiscFile>),
+}
+
+pub struct RunnerInfo {
+    /// The name of the runner to use
+    pub runner_name: String,
+
+    /// The required framework version range to run the model with
+    /// This is a semver version range. See https://docs.rs/semver/1.0.16/semver/struct.VersionReq.html
+    /// for format details.
+    /// For example `=1.2.4`, means exactly version `1.2.4`
+    /// In most cases, this should be exactly one version
+    pub required_framework_version: semver::VersionReq,
+
+    /// Don't set this unless you know what you're doing
+    pub runner_compat_version: u64,
+
+    /// Options to pass to the runner. These are runner-specific (e.g.
+    /// PyTorch, TensorFlow, etc).
+    ///
+    /// Sometimes used to configure thread-pool sizes, etc.
+    /// See the documentation for more info
+    pub opts: Option<HashMap<String, RunnerOpt>>,
+}
+
+/// The types of options that can be passed to runners
+pub enum RunnerOpt {
+    Integer(i64),
+    Double(f64),
+    String(String),
+    Boolean(bool),
+    Date(chrono::DateTime<chrono::Utc>),
+}
+
+#[non_exhaustive]
+pub struct TensorSpec {
+    pub name: String,
+
+    /// The datatype
+    pub dtype: DataType,
+
+    /// Tensor shape
+    pub shape: Shape,
+
+    /// Optional description
+    pub description: Option<String>,
+
+    /// Optional internal name
+    pub internal_name: Option<String>,
+}
+
+pub enum Shape {
+    /// Any shape
+    Any,
+
+    /// A symbol for the whole shape
+    Symbol(String),
+
+    /// A list of dimensions
+    /// An empty vec is considered a scalar
+    Shape(Vec<Dimension>),
+}
+
+/// A dimension can be either a fixed value, a symbol, or any value
+pub enum Dimension {
+    Value(u64),
+    Symbol(String),
+    Any,
+}
+
+for_each_carton_type! {
+    #[derive(Debug)]
+    pub enum DataType {
+        $($CartonType,)*
+    }
+}

--- a/source/carton/src/lib.rs
+++ b/source/carton/src/lib.rs
@@ -2,6 +2,7 @@ pub mod types;
 mod format;
 mod http;
 mod load;
+mod info;
 pub mod error;
 
 #[cfg(not(target_family = "wasm"))]

--- a/source/carton/src/types.rs
+++ b/source/carton/src/types.rs
@@ -32,7 +32,7 @@ pub struct LoadOpts {
 }
 
 /// The types of options that can be passed to runners
-pub type RunnerOpt = crate::format::v1::carton_toml::RunnerOpt;
+pub type RunnerOpt = crate::info::RunnerOpt;
 
 /// Supported device types
 #[derive(Debug)]
@@ -104,41 +104,11 @@ impl Device {
 }
 
 /// Options that can be specified when packing a model
-// TODO: add options so we can fill everything in carton.toml
-pub struct PackOpts {
-    /// The name of the model
-    model_name: Option<String>,
-
-    /// The model description
-    model_description: Option<String>,
-
-    /// A list of platforms this model supports
-    /// If empty or unspecified, all platforms are okay
-    required_platforms: Option<Vec<target_lexicon::Triple>>,
-
-    /// The name of the runner to use
-    runner_name: String,
-
-    /// The required framework version range to run the model with
-    /// This is a semver version range. See https://docs.rs/semver/1.0.16/semver/struct.VersionReq.html
-    /// for format details.
-    /// For example `=1.2.4`, means exactly version `1.2.4`
-    required_framework_version_range: semver::VersionReq,
-
-    /// Don't set this unless you know what you're doing
-    runner_compat_version: Option<u64>,
-
-    /// Options to pass to the runner. These are runner-specific (e.g.
-    /// PyTorch, TensorFlow, etc).
-    ///
-    /// Sometimes used to configure thread-pool sizes, etc.
-    /// See the documentation for more info
-    opts: Option<HashMap<String, RunnerOpt>>,
-}
+pub type PackOpts = CartonInfo;
 
 // Directly expose everything in the carton.toml for now
 // TODO: have an intermediate type
-pub type CartonInfo = crate::format::v1::carton_toml::CartonToml;
+pub type CartonInfo = crate::info::CartonInfo;
 
 for_each_carton_type! {
     /// The core tensor type


### PR DESCRIPTION
This PR creates a complete `carton::info::CartonInfo` struct. It also creates a loader in `carton::format::v1::load` that can populate it.

The loader does this by implementing a bunch of type conversions from the structs used in the parsing of the carton.toml file.

Partial implementation of #1 