### PR TITLE
Wire through `load` from the main library to the runner interface

### DIFF
--- a/source/anywhere/src/file_ops.rs
+++ b/source/anywhere/src/file_ops.rs
@@ -83,7 +83,7 @@ where
 }
 
 impl<T: ReadableFileSystem> ReadableFileOps for T where
-    T::FileType: Send + Sync + ReadableFile + Unpin
+    T::FileType: MaybeSend + MaybeSync + ReadableFile + Unpin
 {
 }
 

--- a/source/anywhere/src/rpc.rs
+++ b/source/anywhere/src/rpc.rs
@@ -329,7 +329,7 @@ impl<T: HasFileType> ServerContext<T> where T::FileType: MaybeSend + MaybeSync {
 
 autoimpl! {
     // The following methods need a readable filesystem
-    SECTION: Read requires ReadableFileSystem, ReadableFileOps, Sync; filetype requires ReadableFile, Unpin
+    SECTION: Read requires ReadableFileSystem, ReadableFileOps, MaybeSync; filetype requires ReadableFile, Unpin
     {
         // // Get filesystem capabilities given a token
         // async fn get_fs_type() -> std::io::Result<Capabilities>;
@@ -358,7 +358,7 @@ autoimpl! {
     }
 
     // The following methods need a writable filesystem
-    SECTION: Write requires WritableFileSystem, WritableFileOps, Sync; filetype requires WritableFile, Unpin
+    SECTION: Write requires WritableFileSystem, WritableFileOps, MaybeSync; filetype requires WritableFile, Unpin
     {
         // File IO
         #[with_server_context]
@@ -403,7 +403,7 @@ autoimpl! {
     }
 
     // // The following methods need a seekable filesystem
-    SECTION: Seek requires SeekableFileOps, Sync; filetype requires AsyncSeek, Unpin
+    SECTION: Seek requires SeekableFileOps, MaybeSync; filetype requires AsyncSeek, Unpin
     {
         // File IO
         #[with_server_context]

--- a/source/carton-runner-interface/src/client.rs
+++ b/source/carton-runner-interface/src/client.rs
@@ -3,6 +3,7 @@ use std::sync::{atomic::AtomicU64, Arc};
 use anywhere::{transport::serde::SerdeTransport, Servable};
 use dashmap::DashMap;
 use tokio::sync::{mpsc, oneshot};
+use lunchbox::types::{MaybeSend, MaybeSync};
 
 use crate::{
     do_spawn,
@@ -70,10 +71,10 @@ impl Client {
         out
     }
 
-    async fn serve_fs_with_capabilities<T>(&self, fs: T) -> FsToken
+    pub(crate) async fn serve_readonly_fs<T>(&self, fs: Arc<T>) -> FsToken
     where
-        T: lunchbox::ReadableFileSystem + Send + Sync + 'static,
-        T::FileType: lunchbox::types::ReadableFile + Send + Sync + Unpin,
+        T: lunchbox::ReadableFileSystem + MaybeSend + MaybeSync + 'static,
+        T::FileType: lunchbox::types::ReadableFile + MaybeSend + MaybeSync + Unpin,
     {
         let (tx, rx, id) = self.fs_multiplexer.get_new_stream().await;
 

--- a/source/carton/src/carton.rs
+++ b/source/carton/src/carton.rs
@@ -1,14 +1,19 @@
 use std::collections::HashMap;
 
-use crate::types::{CartonInfo, LoadOpts, PackOpts, SealHandle, Tensor};
+use crate::{types::{CartonInfo, LoadOpts, PackOpts, SealHandle, Tensor}, load::Runner};
 use crate::error::Result;
 
-pub struct Carton {}
+pub struct Carton {
+    info: CartonInfo,
+    runner: Runner,
+}
 
 impl Carton {
     /// Load a carton given a url, path, etc and options
     pub async fn load(url_or_path: String, opts: LoadOpts) -> Result<Self> {
-        todo!()
+        let (info, runner) = crate::load::load(&url_or_path, opts).await?;
+
+        Ok(Self { info, runner })
     }
 
     /// Infer using a set of inputs.
@@ -54,7 +59,7 @@ impl Carton {
 
     /// Get info for the loaded model
     pub fn get_info(&self) -> &CartonInfo {
-        todo!()
+        &self.info
     }
 
     /// Get info for a model

--- a/source/carton/src/format/v1/load.rs
+++ b/source/carton/src/format/v1/load.rs
@@ -25,7 +25,7 @@ where
 async fn load_misc_from_fs<T>(fs: &T, path: &str) -> crate::info::MiscFile
 where
     T: ReadableFileSystem,
-    T::FileType: ReadableFile + 'static,
+    T::FileType: ReadableFile + MaybeSend + MaybeSync + 'static,
 {
     Box::new(fs.open(path).await.unwrap())
 }
@@ -33,7 +33,7 @@ where
 pub async fn load<T>(fs: &Arc<T>) -> Result<CartonInfo>
 where
     T: ReadableFileSystem + MaybeSend + MaybeSync + 'static,
-    T::FileType: ReadableFile + 'static,
+    T::FileType: ReadableFile + MaybeSend + MaybeSync + 'static,
 {
     // Load the toml file
     let toml = fs.read("/carton.toml").await?;
@@ -57,7 +57,7 @@ trait ConvertFrom<T> {
     fn from<F>(item: T, fs: &Arc<F>) -> Self
     where
         F: ReadableFileSystem + MaybeSend + MaybeSync + 'static,
-        F::FileType: ReadableFile + 'static;
+        F::FileType: ReadableFile + MaybeSend + MaybeSync + 'static;
 }
 
 // Something like "into"
@@ -65,7 +65,7 @@ trait ConvertInto<T> {
     fn convert<F>(self, fs: &Arc<F>) -> T
     where
         F: ReadableFileSystem + MaybeSend + MaybeSync + 'static,
-        F::FileType: ReadableFile + 'static;
+        F::FileType: ReadableFile + MaybeSend + MaybeSync + 'static;
 }
 
 // Blanket impl
@@ -76,7 +76,7 @@ where
     fn convert<F>(self, fs: &Arc<F>) -> U
     where
         F: ReadableFileSystem + MaybeSend + MaybeSync + 'static,
-        F::FileType: ReadableFile + 'static,
+        F::FileType: ReadableFile + MaybeSend + MaybeSync + 'static,
     {
         U::from(self, fs)
     }
@@ -89,7 +89,7 @@ where
     fn from<F>(item: Vec<T>, fs: &Arc<F>) -> Self
     where
         F: ReadableFileSystem + MaybeSend + MaybeSync + 'static,
-        F::FileType: ReadableFile + 'static,
+        F::FileType: ReadableFile + MaybeSend + MaybeSync + 'static,
     {
         item.into_iter().map(|v| v.convert(fs)).collect()
     }
@@ -102,7 +102,7 @@ where
     fn from<F>(item: HashMap<String, T>, fs: &Arc<F>) -> Self
     where
         F: ReadableFileSystem + MaybeSend + MaybeSync + 'static,
-        F::FileType: ReadableFile + 'static,
+        F::FileType: ReadableFile + MaybeSend + MaybeSync + 'static,
     {
         item.into_iter().map(|(k, v)| (k, v.convert(fs))).collect()
     }
@@ -115,7 +115,7 @@ where
     fn from<F>(item: Option<T>, fs: &Arc<F>) -> Self
     where
         F: ReadableFileSystem + MaybeSend + MaybeSync + 'static,
-        F::FileType: ReadableFile + 'static,
+        F::FileType: ReadableFile + MaybeSend + MaybeSync + 'static,
     {
         item.map(|v| v.convert(fs))
     }
@@ -153,7 +153,7 @@ impl ConvertFrom<super::carton_toml::TensorReference> for PossiblyLoaded<crate::
     fn from<F>(item: super::carton_toml::TensorReference, fs: &Arc<F>) -> Self
     where
         F: ReadableFileSystem + MaybeSend + MaybeSync + 'static,
-        F::FileType: ReadableFile + 'static,
+        F::FileType: ReadableFile + MaybeSend + MaybeSync + 'static,
     {
         let fs = fs.clone();
         PossiblyLoaded::from_loader(Box::pin(async move {
@@ -166,7 +166,7 @@ impl ConvertFrom<super::carton_toml::MiscFileReference> for PossiblyLoaded<crate
     fn from<F>(item: super::carton_toml::MiscFileReference, fs: &Arc<F>) -> Self
     where
         F: ReadableFileSystem + MaybeSend + MaybeSync + 'static,
-        F::FileType: ReadableFile + 'static,
+        F::FileType: ReadableFile + MaybeSend + MaybeSync + 'static,
     {
         let fs = fs.clone();
         PossiblyLoaded::from_loader(Box::pin(async move {
@@ -179,7 +179,7 @@ impl ConvertFrom<super::carton_toml::TensorOrMiscReference> for crate::info::Ten
     fn from<F>(item: super::carton_toml::TensorOrMiscReference, fs: &Arc<F>) -> Self
     where
         F: ReadableFileSystem + MaybeSend + MaybeSync + 'static,
-        F::FileType: ReadableFile + 'static,
+        F::FileType: ReadableFile + MaybeSend + MaybeSync + 'static,
     {
         match item {
             super::carton_toml::TensorOrMiscReference::T(v) => {
@@ -196,7 +196,7 @@ impl ConvertFrom<super::carton_toml::Example> for crate::info::Example {
     fn from<F>(item: super::carton_toml::Example, fs: &Arc<F>) -> Self
     where
         F: ReadableFileSystem + MaybeSend + MaybeSync + 'static,
-        F::FileType: ReadableFile + 'static,
+        F::FileType: ReadableFile + MaybeSend + MaybeSync + 'static,
     {
         Self {
             name: item.name,
@@ -211,7 +211,7 @@ impl ConvertFrom<super::carton_toml::SelfTest> for crate::info::SelfTest {
     fn from<F>(item: super::carton_toml::SelfTest, fs: &Arc<F>) -> Self
     where
         F: ReadableFileSystem + MaybeSend + MaybeSync + 'static,
-        F::FileType: ReadableFile + 'static,
+        F::FileType: ReadableFile + MaybeSend + MaybeSync + 'static,
     {
         Self {
             name: item.name,

--- a/source/carton/src/load.rs
+++ b/source/carton/src/load.rs
@@ -157,7 +157,8 @@ async fn discover_or_get_runner_and_launch<T>(
     visible_device: Device,
 ) -> Runner
 where
-    T: lunchbox::ReadableFileSystem,
+    T: lunchbox::ReadableFileSystem + MaybeSend + MaybeSync + 'static,
+    T::FileType: lunchbox::types::ReadableFile + MaybeSend + MaybeSync + Unpin,
 {
     // TODO: maybe we want to just do this once at startup or cache it?
     let local_runners = crate::discovery::discover_runners().await;


### PR DESCRIPTION
This PR passes through `load` calls from `carton` to `carton-runner-interface` and fixes a bunch of `Send` + `Sync` issues to make things compile

cc #12 