### PR TITLE
Implement `load` in `carton-runner-interface`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,6 +115,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,6 +152,7 @@ dependencies = [
  "reqwest",
  "semver 1.0.16",
  "serde",
+ "sha2",
  "target-lexicon",
  "tempfile",
  "thiserror",
@@ -190,11 +200,13 @@ dependencies = [
  "anywhere",
  "bincode",
  "carton-macros",
+ "chrono",
  "clap",
  "dashmap",
  "js-sys",
  "lunchbox",
  "ndarray",
+ "semver 1.0.16",
  "sendfd",
  "serde",
  "tempfile",
@@ -307,12 +319,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -405,6 +436,16 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -573,6 +614,16 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1597,6 +1648,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1840,6 +1902,12 @@ name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+
+[[package]]
+name = "typenum"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicode-bidi"

--- a/source/carton-runner-interface/Cargo.toml
+++ b/source/carton-runner-interface/Cargo.toml
@@ -13,6 +13,8 @@ carton-macros = { path = "../carton-macros" }
 ndarray = { version = "0.15", features = ["serde"] }
 anywhere = { path = "../anywhere" }
 lunchbox = { version = "0.1", features = ["serde"], default-features = false }
+semver = {version = "1.0.16", features = ["serde"]}
+chrono = {version = "0.4.23", features = ["serde"]}
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 # This version is pinned because we don't want to accidentally break our transport

--- a/source/carton-runner-interface/src/do_not_modify/types.rs
+++ b/source/carton-runner-interface/src/do_not_modify/types.rs
@@ -60,12 +60,10 @@ pub enum RPCRequestData {
         /// For a readonly filesystem
         fs: FsToken,
 
-        runner_name: Option<String>,
-        required_framework_version: Option<String>,
+        runner_name: String,
+        required_framework_version: semver::VersionReq,
         runner_compat_version: u64,
-
-        // TODO: fix this
-        runner_opts: Option<String>,
+        runner_opts: Option<HashMap<String, RunnerOpt>>,
         visible_device: Device,
 
         // The hash of the model
@@ -104,12 +102,8 @@ pub enum RPCRequestData {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub enum RPCResponseData {
-    Load {
-        name: String,
-        
-        // TODO: Change this to a runnerinfo struct
-        runner: String,
-    },
+    // Doesn't return anything on successful load
+    Load,
 
     Pack {
         // The path to the output directory. This can be in the temp folder passed into `Pack`
@@ -137,6 +131,17 @@ pub enum RPCResponseData {
         e: String,
     }
 
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub enum RunnerOpt {
+    Integer(i64),
+    Double(f64),
+    String(String),
+    Boolean(bool),
+
+    // Serializes into a rfc3339 time string so this should be fine to put on the wire
+    Date(chrono::DateTime<chrono::Utc>),
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, Serialize, Deserialize)]

--- a/source/carton-runner-noop/src/main.rs
+++ b/source/carton-runner-noop/src/main.rs
@@ -23,10 +23,7 @@ async fn main() {
                 server
                     .send_response_for_request(
                         req_id,
-                        RPCResponseData::Load {
-                            name: "model_name".to_string(),
-                            runner: "noop".to_string(),
-                        },
+                        RPCResponseData::Load,
                     )
                     .await
                     .unwrap();

--- a/source/carton/Cargo.toml
+++ b/source/carton/Cargo.toml
@@ -24,6 +24,7 @@ url = "2.3.1"
 async-trait = "0.1"
 runner_interface_v1 = { package = "carton-runner-interface", path = "../carton-runner-interface" }
 thiserror = "1"
+sha2 = "0.10.6"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 nvml-wrapper = "0.8.0"

--- a/source/carton/src/carton.rs
+++ b/source/carton/src/carton.rs
@@ -1,10 +1,10 @@
 use std::collections::HashMap;
 
-use crate::{types::{CartonInfo, LoadOpts, PackOpts, SealHandle, Tensor}, load::Runner};
+use crate::{types::{CartonInfo, LoadOpts, PackOpts, SealHandle, Tensor}, load::Runner, info::CartonInfoWithExtras};
 use crate::error::Result;
 
 pub struct Carton {
-    info: CartonInfo,
+    info: CartonInfoWithExtras,
     runner: Runner,
 }
 
@@ -59,12 +59,12 @@ impl Carton {
 
     /// Get info for the loaded model
     pub fn get_info(&self) -> &CartonInfo {
-        &self.info
+        &self.info.info
     }
 
     /// Get info for a model
     pub async fn get_model_info(url_or_path: String) -> Result<CartonInfo> {
-        crate::load::get_carton_info(&url_or_path).await
+        Ok(crate::load::get_carton_info(&url_or_path).await?.info)
     }
 
     /// Allocate a tensor

--- a/source/carton/src/info.rs
+++ b/source/carton/src/info.rs
@@ -38,6 +38,15 @@ pub struct CartonInfo {
     pub runner: RunnerInfo,
 }
 
+/// An internal struct used when loading models. It contains extra things like the
+/// manifest hash
+pub(crate) struct CartonInfoWithExtras {
+    pub(crate) info: CartonInfo,
+
+    /// The sha256 of the MANIFEST file
+    pub(crate) manifest_sha256: String,
+}
+
 #[cfg(target_family = "wasm")]
 pub type BoxFuture<'a, T> = Pin<Box<dyn std::future::Future<Output = T> + 'a>>;
 
@@ -138,6 +147,7 @@ pub struct RunnerInfo {
 }
 
 /// The types of options that can be passed to runners
+#[derive(Clone)]
 pub enum RunnerOpt {
     Integer(i64),
     Double(f64),

--- a/source/carton/src/types.rs
+++ b/source/carton/src/types.rs
@@ -36,7 +36,7 @@ pub struct LoadOpts {
 pub type RunnerOpt = crate::info::RunnerOpt;
 
 /// Supported device types
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub enum Device {
     #[default]
     CPU,


### PR DESCRIPTION
This PR updates `load` to actually send an RPC request. In order to do this, it also updates `carton::load` and `carton::format::v1::load` to compute the sha256 of the `MANIFEST` file.

cc #12 