### PR TITLE
Change build configuration to correctly preserve build cache

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,3 +2,7 @@
 
 # This lets us use tokio's tracing feature (which we need for tokio-console)
 rustflags = ["--cfg", "tokio_unstable"]
+
+# Set a default target so that build caches are saved correctly when switching targets
+# https://doc.rust-lang.org/cargo/guide/build-cache.html
+target = ["x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
Linux only for now, but we can refactor later when we add macOS support