### PR TITLE
Make tensors generic over storage

### DIFF
--- a/source/carton-bindings-nodejs/src/lib.rs
+++ b/source/carton-bindings-nodejs/src/lib.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use carton::{
-    types::{for_each_carton_type, Device, LoadOpts, Tensor},
+    types::{for_each_carton_type, Device, GenericStorage, LoadOpts, Tensor},
     Carton,
 };
 use ndarray::ShapeBuilder;
@@ -143,13 +143,13 @@ impl CartonWrapper {
             // TODO this makes another copy (the `to_owned`)
             // TODO: we should ignore strings here
             for_each_carton_type! {
-                let t: Tensor = match dtype.as_str() {
+                let t: Tensor<GenericStorage> = match dtype.as_str() {
                     $(
                         $TypeStr => unsafe {
-                            ndarray::ArrayView::from_shape_ptr(
+                            Tensor::$CartonType(ndarray::ArrayView::from_shape_ptr(
                                 shape.strides(stride),
                                 buffer.as_ptr() as *const $RustType,
-                            ).to_owned().into()
+                            ).to_owned())
                         },
                     )*
                     dtype => panic!("Got unknown dtype: {dtype}"),

--- a/source/carton-bindings-py/src/lib.rs
+++ b/source/carton-bindings-py/src/lib.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, sync::Arc};
 
-use carton_core::types::{Device, LoadOpts, RunnerOpt, Tensor};
+use carton_core::types::{Device, GenericStorage, LoadOpts, RunnerOpt, Tensor};
 use numpy::{PyArrayDyn, ToPyArray};
 use pyo3::{exceptions::PyValueError, prelude::*, types::PyDict};
 
@@ -51,7 +51,7 @@ impl Carton {
 
         for (k, v) in tensors {
             // TODO: this makes a copy
-            let native = match v {
+            let native: Tensor<GenericStorage> = match v {
                 SupportedTensorType::Float(item) => Tensor::Float(item.to_owned_array()),
                 SupportedTensorType::Double(item) => Tensor::Double(item.to_owned_array()),
 
@@ -83,7 +83,7 @@ impl Carton {
 
         for (k, v) in tensors {
             // TODO: this makes a copy
-            let native = match v {
+            let native: Tensor<GenericStorage> = match v {
                 SupportedTensorType::Float(item) => Tensor::Float(item.to_owned_array()),
                 SupportedTensorType::Double(item) => Tensor::Double(item.to_owned_array()),
 

--- a/source/carton/benches/bench_noop_infer.rs
+++ b/source/carton/benches/bench_noop_infer.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 use carton::{
     info::RunnerInfo,
-    types::{CartonInfo, LoadOpts},
+    types::{CartonInfo, GenericStorage, LoadOpts},
     Carton,
 };
 use criterion::{criterion_group, criterion_main, Criterion};
@@ -54,7 +54,7 @@ platform = "{}"
     println!("Creating runtime");
     let runtime = tokio::runtime::Runtime::new().unwrap();
 
-    let pack_opts = CartonInfo {
+    let pack_opts: CartonInfo<GenericStorage> = CartonInfo {
         model_name: None,
         model_description: None,
         required_platforms: None,
@@ -78,7 +78,7 @@ platform = "{}"
 
     c.bench_function("infer_noop", |b| {
         b.to_async(&runtime).iter(|| async {
-            let tensors: HashMap<String, carton::types::Tensor> = HashMap::new();
+            let tensors: HashMap<String, carton::types::Tensor<GenericStorage>> = HashMap::new();
             carton.infer_with_inputs(tensors).await.unwrap();
         })
     });

--- a/source/carton/src/conversion_utils.rs
+++ b/source/carton/src/conversion_utils.rs
@@ -30,3 +30,30 @@ where
 {
     v.map(|item| convert_map(item))
 }
+
+/// Several useful conversions are not allowed by rust because they happen to overlap with the core
+/// `impl<T> From<T> for T`.
+///
+/// For example, if we wanted to convert any tensor to a GenericTensor, we couldn't implement `From`
+/// because it overlaps with converting a `GenericTensor` to a `GenericTensor` (i.e. From<T> for T)
+///
+/// Therefore, we create a separate conversion trait that is almost identical to From, but it doesn't
+/// have an impl for From<T> for T
+pub(crate) trait ConvertFrom<T> {
+    fn from(value: T) -> Self;
+}
+
+// Something like "into"
+pub(crate) trait ConvertInto<T> {
+    fn convert_into(self) -> T;
+}
+
+// Blanket impl
+impl<T, U> ConvertInto<U> for T
+where
+    U: ConvertFrom<T>,
+{
+    fn convert_into(self) -> U {
+        U::from(self)
+    }
+}

--- a/source/carton/src/format/v1/load.rs
+++ b/source/carton/src/format/v1/load.rs
@@ -12,9 +12,9 @@ use sha2::{Digest, Sha256};
 use crate::conversion_utils::{convert_opt_map, convert_opt_vec, convert_vec};
 use crate::error::{CartonError, Result};
 use crate::info::{CartonInfoWithExtras, PossiblyLoaded};
-use crate::types::CartonInfo;
+use crate::types::{CartonInfo, GenericStorage};
 
-async fn load_tensor_from_fs<T>(fs: &T, path: &str) -> crate::types::Tensor
+async fn load_tensor_from_fs<T>(fs: &T, path: &str) -> crate::types::Tensor<GenericStorage>
 where
     T: ReadableFileSystem,
     T::FileType: ReadableFile + 'static,
@@ -32,7 +32,7 @@ where
     Box::new(fs.open(path).await.unwrap())
 }
 
-pub(crate) async fn load<T>(fs: &Arc<T>) -> Result<CartonInfoWithExtras>
+pub(crate) async fn load<T>(fs: &Arc<T>) -> Result<CartonInfoWithExtras<GenericStorage>>
 where
     T: ReadableFileSystem + MaybeSend + MaybeSync + 'static,
     T::FileType: ReadableFile + MaybeSend + MaybeSync + 'static,
@@ -174,7 +174,9 @@ where
     }
 }
 
-impl ConvertFrom<super::carton_toml::TensorReference> for PossiblyLoaded<crate::types::Tensor> {
+impl ConvertFrom<super::carton_toml::TensorReference>
+    for PossiblyLoaded<crate::types::Tensor<GenericStorage>>
+{
     fn from<F>(item: super::carton_toml::TensorReference, fs: &Arc<F>) -> Self
     where
         F: ReadableFileSystem + MaybeSend + MaybeSync + 'static,
@@ -200,7 +202,9 @@ impl ConvertFrom<super::carton_toml::MiscFileReference> for PossiblyLoaded<crate
     }
 }
 
-impl ConvertFrom<super::carton_toml::TensorOrMiscReference> for crate::info::TensorOrMisc {
+impl ConvertFrom<super::carton_toml::TensorOrMiscReference>
+    for crate::info::TensorOrMisc<GenericStorage>
+{
     fn from<F>(item: super::carton_toml::TensorOrMiscReference, fs: &Arc<F>) -> Self
     where
         F: ReadableFileSystem + MaybeSend + MaybeSync + 'static,
@@ -217,7 +221,7 @@ impl ConvertFrom<super::carton_toml::TensorOrMiscReference> for crate::info::Ten
     }
 }
 
-impl ConvertFrom<super::carton_toml::Example> for crate::info::Example {
+impl ConvertFrom<super::carton_toml::Example> for crate::info::Example<GenericStorage> {
     fn from<F>(item: super::carton_toml::Example, fs: &Arc<F>) -> Self
     where
         F: ReadableFileSystem + MaybeSend + MaybeSync + 'static,
@@ -232,7 +236,7 @@ impl ConvertFrom<super::carton_toml::Example> for crate::info::Example {
     }
 }
 
-impl ConvertFrom<super::carton_toml::SelfTest> for crate::info::SelfTest {
+impl ConvertFrom<super::carton_toml::SelfTest> for crate::info::SelfTest<GenericStorage> {
     fn from<F>(item: super::carton_toml::SelfTest, fs: &Arc<F>) -> Self
     where
         F: ReadableFileSystem + MaybeSend + MaybeSync + 'static,

--- a/source/carton/src/format/v1/save.rs
+++ b/source/carton/src/format/v1/save.rs
@@ -1,11 +1,14 @@
 use crate::error::Result;
-use crate::types::CartonInfo;
+use crate::types::{CartonInfo, TensorStorage};
 
 /// Given a path to a filled `model` dir, this function creates a complete carton by saving all the additonal
 /// info. Returns a path to the saved file
-pub(crate) async fn save(
-    info: CartonInfo,
+pub(crate) async fn save<T>(
+    info: CartonInfo<T>,
     model_dir_path: &std::path::Path,
-) -> Result<std::path::PathBuf> {
+) -> Result<std::path::PathBuf>
+where
+    T: TensorStorage,
+{
     todo!()
 }


### PR DESCRIPTION
This PR makes `Tensor` generic over storage types.

This makes it easier to integrate with third party tensor types in the bindings