### PR TITLE
Refactor the python bindings to use `TensorStorage`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,6 +278,7 @@ name = "carton-bindings-py"
 version = "0.1.0"
 dependencies = [
  "carton",
+ "ndarray",
  "numpy",
  "pyo3",
  "pyo3-asyncio",

--- a/source/carton-bindings-py/Cargo.toml
+++ b/source/carton-bindings-py/Cargo.toml
@@ -12,3 +12,4 @@ pyo3 = { version = "0.17.3", features = ["extension-module"] }
 pyo3-asyncio = { version = "0.17", features = ["attributes", "tokio-runtime"] }
 carton-core = { package = "carton", path = "../carton" }
 numpy = "0.17"
+ndarray = { version = "0.15" }


### PR DESCRIPTION
This PR implements a `PyTensorStorage` type in the python bindings. This lets us avoid a copy when accepting a numpy array from python.