### PR TITLE
Add an inline storage type to the runner interface

### DIFF
--- a/source/carton-bindings-nodejs/src/lib.rs
+++ b/source/carton-bindings-nodejs/src/lib.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use carton::{
-    types::{for_each_carton_type, Device, GenericStorage, LoadOpts, Tensor},
+    types::{for_each_carton_type, Device, GenericStorage, LoadOpts, Tensor, TypedStorage},
     Carton,
 };
 use ndarray::ShapeBuilder;
@@ -191,7 +191,8 @@ impl CartonWrapper {
                                 Tensor::$CartonType(t) => {
                                     // Get the data as a slice
                                     // TODO: this can make a copy
-                                    let mut standard = t.as_standard_layout();
+                                    let view = t.view();
+                                    let mut standard = view.as_standard_layout();
 
                                     let data = standard.as_slice_mut().unwrap();
 
@@ -206,7 +207,7 @@ impl CartonWrapper {
                                     let buf = JsArrayBuffer::external(&mut cx, data);
 
                                     // Get the shape
-                                    let shape = vec_to_array(&mut cx, t.shape())?;
+                                    let shape = vec_to_array(&mut cx, view.shape())?;
 
                                     let typestr = cx.string($TypeStr);
                                     let keystr = cx.string(k);

--- a/source/carton-bindings-py/src/lib.rs
+++ b/source/carton-bindings-py/src/lib.rs
@@ -156,18 +156,18 @@ impl Carton {
                 // TODO this makes a copy
                 let pytype = Python::with_gil(|py| {
                     match v {
-                        Tensor::Float(item) => item.to_pyarray(py).to_object(py),
-                        Tensor::Double(item) => item.to_pyarray(py).to_object(py),
-                        // Tensor::String(item) => item.to_pyarray(py).to_object(py),
+                        Tensor::Float(item) => item.view().to_pyarray(py).to_object(py),
+                        Tensor::Double(item) => item.view().to_pyarray(py).to_object(py),
+                        // Tensor::String(item) => item.view().to_pyarray(py).to_object(py),
                         Tensor::String(_) => panic!("String tensor output not implemented yet"),
-                        Tensor::I8(item) => item.to_pyarray(py).to_object(py),
-                        Tensor::I16(item) => item.to_pyarray(py).to_object(py),
-                        Tensor::I32(item) => item.to_pyarray(py).to_object(py),
-                        Tensor::I64(item) => item.to_pyarray(py).to_object(py),
-                        Tensor::U8(item) => item.to_pyarray(py).to_object(py),
-                        Tensor::U16(item) => item.to_pyarray(py).to_object(py),
-                        Tensor::U32(item) => item.to_pyarray(py).to_object(py),
-                        Tensor::U64(item) => item.to_pyarray(py).to_object(py),
+                        Tensor::I8(item) => item.view().to_pyarray(py).to_object(py),
+                        Tensor::I16(item) => item.view().to_pyarray(py).to_object(py),
+                        Tensor::I32(item) => item.view().to_pyarray(py).to_object(py),
+                        Tensor::I64(item) => item.view().to_pyarray(py).to_object(py),
+                        Tensor::U8(item) => item.view().to_pyarray(py).to_object(py),
+                        Tensor::U16(item) => item.view().to_pyarray(py).to_object(py),
+                        Tensor::U32(item) => item.view().to_pyarray(py).to_object(py),
+                        Tensor::U64(item) => item.view().to_pyarray(py).to_object(py),
                         Tensor::NestedTensor(_) => {
                             panic!("Nested tensor output not implemented yet")
                         }
@@ -193,18 +193,18 @@ impl Carton {
                 // TODO this makes a copy
                 let pytype = Python::with_gil(|py| {
                     match v {
-                        Tensor::Float(item) => item.to_pyarray(py).to_object(py),
-                        Tensor::Double(item) => item.to_pyarray(py).to_object(py),
-                        // Tensor::String(item) => item.to_pyarray(py).to_object(py),
+                        Tensor::Float(item) => item.view().to_pyarray(py).to_object(py),
+                        Tensor::Double(item) => item.view().to_pyarray(py).to_object(py),
+                        // Tensor::String(item) => item.view().to_pyarray(py).to_object(py),
                         Tensor::String(_) => panic!("String tensor output not implemented yet"),
-                        Tensor::I8(item) => item.to_pyarray(py).to_object(py),
-                        Tensor::I16(item) => item.to_pyarray(py).to_object(py),
-                        Tensor::I32(item) => item.to_pyarray(py).to_object(py),
-                        Tensor::I64(item) => item.to_pyarray(py).to_object(py),
-                        Tensor::U8(item) => item.to_pyarray(py).to_object(py),
-                        Tensor::U16(item) => item.to_pyarray(py).to_object(py),
-                        Tensor::U32(item) => item.to_pyarray(py).to_object(py),
-                        Tensor::U64(item) => item.to_pyarray(py).to_object(py),
+                        Tensor::I8(item) => item.view().to_pyarray(py).to_object(py),
+                        Tensor::I16(item) => item.view().to_pyarray(py).to_object(py),
+                        Tensor::I32(item) => item.view().to_pyarray(py).to_object(py),
+                        Tensor::I64(item) => item.view().to_pyarray(py).to_object(py),
+                        Tensor::U8(item) => item.view().to_pyarray(py).to_object(py),
+                        Tensor::U16(item) => item.view().to_pyarray(py).to_object(py),
+                        Tensor::U32(item) => item.view().to_pyarray(py).to_object(py),
+                        Tensor::U64(item) => item.view().to_pyarray(py).to_object(py),
                         Tensor::NestedTensor(_) => {
                             panic!("Nested tensor output not implemented yet")
                         }

--- a/source/carton-runner-interface/src/do_not_modify/inline_storage.rs
+++ b/source/carton-runner-interface/src/do_not_modify/inline_storage.rs
@@ -1,0 +1,95 @@
+//! TensorStorage that is stored inline
+
+use carton_macros::for_each_numeric_carton_type;
+use ndarray::{ShapeBuilder, StrideShape};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TensorStorage<T> {
+    // TODO: use a vec<u8> for primitive types
+    data: Vec<T>,
+    shape: Vec<u64>,
+    strides: Option<Vec<u64>>,
+}
+
+impl<T> TensorStorage<T> {
+    fn get_shape(&self) -> StrideShape<ndarray::IxDyn> {
+        match &self.strides {
+            None => self
+                .shape
+                .iter()
+                .map(|v| *v as usize)
+                .collect::<Vec<_>>()
+                .into(),
+            Some(strides) => self
+                .shape
+                .iter()
+                .map(|v| *v as usize)
+                .collect::<Vec<_>>()
+                .strides(strides.iter().map(|v| (*v).try_into().unwrap()).collect())
+                .into(),
+        }
+    }
+
+    pub fn view(&self) -> ndarray::ArrayViewD<T> {
+        let data = self.data.as_ptr();
+        unsafe { ndarray::ArrayView::from_shape_ptr(self.get_shape(), data) }
+    }
+
+    pub fn view_mut(&mut self) -> ndarray::ArrayViewMutD<T> {
+        let data = self.data.as_mut_ptr();
+        unsafe { ndarray::ArrayViewMut::from_shape_ptr(self.get_shape(), data) }
+    }
+}
+
+// Copy the data
+impl<T: NumericCartonType> From<ndarray::ArrayViewD<'_, T>> for TensorStorage<T> {
+    fn from(view: ndarray::ArrayViewD<'_, T>) -> Self {
+        // Alloc a tensor
+        let mut out = alloc_tensor(view.shape().iter().map(|v| (*v) as _).collect());
+
+        if view.is_standard_layout() {
+            // We can just memcpy the data
+            out.view_mut()
+                .as_slice_mut()
+                .unwrap()
+                .copy_from_slice(view.as_slice().unwrap())
+        } else {
+            out.view_mut().assign(&view);
+        }
+
+        out
+    }
+}
+
+impl From<ndarray::ArrayViewD<'_, String>> for TensorStorage<String> {
+    fn from(view: ndarray::ArrayViewD<'_, String>) -> Self {
+        // Alloc a tensor
+        let mut out = alloc_tensor(view.shape().iter().map(|v| (*v) as _).collect());
+
+        // Can't memcpy
+        out.view_mut().assign(&view);
+
+        out
+    }
+}
+
+// Allocates a contiguous tensor with a shape and type
+pub(crate) fn alloc_tensor<T: Default + Clone>(shape: Vec<u64>) -> TensorStorage<T> {
+    let numel: u64 = shape.iter().product();
+    let data: Vec<T> = vec![T::default(); numel as _];
+
+    TensorStorage {
+        data,
+        shape,
+        strides: None,
+    }
+}
+
+trait NumericCartonType: Default + Copy {}
+
+for_each_numeric_carton_type! {
+    $(
+        impl NumericCartonType for $RustType {}
+    )*
+}

--- a/source/carton-runner-interface/src/do_not_modify/mod.rs
+++ b/source/carton-runner-interface/src/do_not_modify/mod.rs
@@ -1,4 +1,5 @@
 mod framed;
+mod inline_storage;
 pub mod types;
 
 if_not_wasm! {

--- a/source/carton-runner-interface/src/do_not_modify/types.rs
+++ b/source/carton-runner-interface/src/do_not_modify/types.rs
@@ -165,7 +165,7 @@ for_each_carton_type! {
     /// staying the same. Or just pin to a specific ndarray version
     #[derive(Debug, Serialize, Deserialize)]
     pub enum Tensor {
-        $($CartonType(ndarray::ArrayD::<$RustType>),)*
+        $($CartonType(TensorStorage::<$RustType>),)*
 
         /// A Nested Tensor / Ragged Tensor
         /// See the docs in the core carton library for more details
@@ -173,10 +173,12 @@ for_each_carton_type! {
     }
 }
 
+pub type TensorStorage<T> = super::inline_storage::TensorStorage<T>;
+
 for_each_carton_type! {
     $(
-        impl From<ndarray::ArrayD<$RustType>> for Tensor {
-            fn from(item: ndarray::ArrayD<$RustType>) -> Self {
+        impl From<TensorStorage<$RustType>> for Tensor {
+            fn from(item: TensorStorage<$RustType>) -> Self {
                 Tensor::$CartonType(item)
             }
         }

--- a/source/carton/src/carton.rs
+++ b/source/carton/src/carton.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use crate::error::Result;
 use crate::load::discover_or_get_runner_and_launch;
+use crate::runner_interface::storage::RunnerStorage;
 use crate::types::{GenericStorage, TensorStorage};
 use crate::{
     conversion_utils::convert_map,
@@ -37,7 +38,7 @@ impl Carton {
     pub async fn infer_with_inputs<T>(
         &self,
         tensors: HashMap<String, Tensor<T>>,
-    ) -> Result<HashMap<String, Tensor<GenericStorage>>>
+    ) -> Result<HashMap<String, Tensor<RunnerStorage>>>
     where
         T: TensorStorage,
     {
@@ -73,7 +74,7 @@ impl Carton {
     pub async fn infer_with_handle(
         &self,
         handle: SealHandle,
-    ) -> Result<HashMap<String, Tensor<GenericStorage>>> {
+    ) -> Result<HashMap<String, Tensor<RunnerStorage>>> {
         match &self.runner {
             Runner::V1(runner) => Ok(convert_map(
                 runner

--- a/source/carton/src/runner_interface/mod.rs
+++ b/source/carton/src/runner_interface/mod.rs
@@ -1,1 +1,2 @@
+pub(crate) mod storage;
 mod v1;

--- a/source/carton/src/runner_interface/storage.rs
+++ b/source/carton/src/runner_interface/storage.rs
@@ -1,0 +1,30 @@
+//! Implementation of an enum that wraps all the runner tensor types and provides storage
+
+use crate::types::{TensorStorage, TypedStorage};
+use lunchbox::types::{MaybeSend, MaybeSync};
+
+pub struct RunnerStorage;
+
+impl TensorStorage for RunnerStorage {
+    type TypedStorage<T> = TypedRunnerStorage<T>
+    where
+        T: MaybeSend + MaybeSync;
+}
+
+pub enum TypedRunnerStorage<T> {
+    V1(runner_interface_v1::types::TensorStorage<T>),
+}
+
+impl<T> TypedStorage<T> for TypedRunnerStorage<T> {
+    fn view(&self) -> ndarray::ArrayViewD<T> {
+        match self {
+            TypedRunnerStorage::V1(s) => s.view(),
+        }
+    }
+
+    fn view_mut(&mut self) -> ndarray::ArrayViewMutD<T> {
+        match self {
+            TypedRunnerStorage::V1(s) => s.view_mut(),
+        }
+    }
+}

--- a/source/carton/src/runner_interface/v1/types.rs
+++ b/source/carton/src/runner_interface/v1/types.rs
@@ -3,7 +3,8 @@
 use crate::conversion_utils::convert_vec;
 use carton_macros::for_each_carton_type;
 
-use crate::types::{Device, GenericStorage, RunnerOpt, Tensor, TensorStorage, TypedStorage};
+use crate::runner_interface::storage::{RunnerStorage, TypedRunnerStorage};
+use crate::types::{Device, RunnerOpt, Tensor, TensorStorage, TypedStorage};
 
 impl From<Device> for runner_interface_v1::types::Device {
     fn from(value: Device) -> Self {
@@ -31,19 +32,19 @@ for_each_carton_type! {
         fn from(value: Tensor<T>) -> Self {
             match value {
                 $(
-                    // TODO: this always makes a copy
-                    Tensor::$CartonType(v) => Self::$CartonType(v.view().to_owned()),
+                    Tensor::$CartonType(v) => Self::$CartonType(v.view().into()),
                 )*
                 Tensor::NestedTensor(v) => Self::NestedTensor(convert_vec(v)),
             }
         }
     }
 
-    impl From<runner_interface_v1::types::Tensor> for Tensor<GenericStorage> {
+    impl From<runner_interface_v1::types::Tensor> for Tensor<RunnerStorage> {
         fn from(value: runner_interface_v1::types::Tensor) -> Self {
             match value {
                 $(
-                    runner_interface_v1::types::Tensor::$CartonType(v) => Self::$CartonType(v),
+                    // TODO: this makes a copy
+                    runner_interface_v1::types::Tensor::$CartonType(v) => Self::$CartonType(TypedRunnerStorage::V1(v)),
                 )*
                 runner_interface_v1::types::Tensor::NestedTensor(v) => Self::NestedTensor(convert_vec(v)),
             }


### PR DESCRIPTION
This PR replaces the Tensor storage type of the runner interface with a type that stores the data in a `Vec<T>`. It also creates a `RunnerStorage` type in the core library on top of this type.