### PR TITLE
Tensor allocator that reuses allocations + benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,14 +301,17 @@ dependencies = [
  "bincode",
  "carton-macros",
  "clap 4.1.1",
+ "criterion",
  "dashmap",
  "js-sys",
  "libc",
  "lunchbox",
  "ndarray",
+ "once_cell",
  "semver 1.0.16",
  "sendfd",
  "serde",
+ "serde_bytes",
  "tempfile",
  "tokio",
  "wasm-bindgen",
@@ -1537,9 +1540,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "oorandom"

--- a/source/carton-runner-interface/Cargo.toml
+++ b/source/carton-runner-interface/Cargo.toml
@@ -14,6 +14,8 @@ ndarray = { version = "0.15", features = ["serde"] }
 anywhere = { path = "../anywhere" }
 lunchbox = { version = "0.1", features = ["serde"], default-features = false }
 semver = {version = "1.0.16", features = ["serde"]}
+once_cell = "1.17.0"
+serde_bytes = "0.11"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 # This version is pinned because we don't want to accidentally break our transport
@@ -28,3 +30,16 @@ wasm-bindgen = "0.2"
 wasm-streams = "0.3.0"
 js-sys = "0.3.60"
 wasm-bindgen-futures = "0.4.33"
+
+[dev-dependencies]
+criterion = {version = "0.4", features = ["html_reports"]}
+
+[[bench]]
+name = "bench_alloc"
+harness = false
+required-features = ["benchmark"]
+
+[features]
+
+# This feature should only be used in benchmarks
+benchmark = []

--- a/source/carton-runner-interface/benches/README.md
+++ b/source/carton-runner-interface/benches/README.md
@@ -1,0 +1,43 @@
+# Benchmark analysis
+
+*Note: this analysis was done on 1/31/22. The results of benchmarks may have varied since then*
+
+**TL;DR: An allocator that reuses previous allocations provides superior performance**
+
+## Overview
+
+This benchmark compares three things:
+
+- Allocating storage for a tensor and filling with a non-default value.
+  - (`inline_storage_without_pool` in the plots below)
+- Allocating storage for a tensor using a pool of previously allocated and dropped items (falling back to a standard alloc if none are available) and filling with a non-default value.
+  - (`inline_storage_with_pool` in the plots below)
+- Filling an existing allocation with a non-default value.
+  - (`fill_existing_tensor` in the plots below)
+
+The purpose of the non-default fill is to ensure that the storage is not lazily allocated (with zero pages, for example). This also allows us to include data access times in the benchmark.
+
+This is a useful benchmark under the following assumption:
+
+- Repeated allocations of the same size/shape are common in inference workloads.
+
+This is generally true for image-based models. Text models and other variable sized models are not currently included in this benchmark. They will be measured in the future.
+
+## Results
+
+As expected, reusing previous allocations leads to significant performance boosts, especially with larger tensors.
+
+As you can see in the plot below, for large allocations (~ HD images), reusing previous allocations is ~14ms faster than allocating a new chunk of memory.
+
+![](./lines.svg)
+
+Here's a **log-log** plot of results of the same benchmark. For small allocations, the pool allocator is ~60 nanoseconds slower than the naive one and larger allocations approach the performance of "fill an existing allocation". This implies that the allocation time of the pool allocator approaches zero as the sizes increase.
+
+![](./lines_log.svg)
+
+
+So in the worst case, the pool allocator is 60 *nanoseconds* slower than an allocator without a pool and best case (in this benchmark) it's 14 *milliseconds* faster. Therefore, we enable the pool allocator by default.
+
+## Future exploration
+
+We should redo this analysis once a LRU cache is implemented within the pool. We should also test on allocation patterns that don't match the assumption above to ensure that performance is still good.

--- a/source/carton-runner-interface/benches/bench_alloc.rs
+++ b/source/carton-runner-interface/benches/bench_alloc.rs
@@ -1,0 +1,104 @@
+//! This benchmark measures tensor allocation overhead
+use carton_macros::for_each_numeric_carton_type;
+use carton_runner_interface::_only_public_for_benchmarks_do_not_use::{
+    alloc_tensor, alloc_tensor_no_pool, Allocator, InlineTensorStorage, TypedAlloc,
+};
+use criterion::{
+    criterion_group, criterion_main, measurement::Measurement, AxisScale, BenchmarkGroup,
+    BenchmarkId, Criterion, PlotConfiguration, Throughput,
+};
+
+/// Note: this benchmark allocates *and fills* a tensor. Otherwise for large allocs, the allocation
+/// ends up being very fast because it just allocates zero pages (and then the first writes are slow)
+fn typed_alloc_benchmark<T: Clone + Default, U: Measurement>(
+    name: &str,
+    group: &mut BenchmarkGroup<U>,
+    shape: &Vec<u64>,
+    fill_value: T,
+) where
+    Allocator: TypedAlloc<T, Output = InlineTensorStorage>,
+{
+    let numel = shape.iter().product::<u64>();
+    let size_bytes = std::mem::size_of::<T>() as u64 * numel;
+    group.throughput(Throughput::Bytes(size_bytes));
+    group.bench_with_input(
+        BenchmarkId::new(
+            "inline_storage_with_pool",
+            name.to_owned() + "_" + std::any::type_name::<T>(),
+        ),
+        shape,
+        |b, shape| {
+            b.iter(|| {
+                let mut t = alloc_tensor::<T>(shape.clone());
+                t.view_mut()
+                    .as_slice_mut()
+                    .unwrap()
+                    .fill(fill_value.clone());
+            })
+        },
+    );
+
+    group.bench_with_input(
+        BenchmarkId::new(
+            "inline_storage_without_pool",
+            name.to_owned() + "_" + std::any::type_name::<T>(),
+        ),
+        shape,
+        |b, shape| {
+            b.iter(|| {
+                let mut t = alloc_tensor_no_pool::<T>(shape.clone());
+                t.view_mut()
+                    .as_slice_mut()
+                    .unwrap()
+                    .fill(fill_value.clone());
+            })
+        },
+    );
+
+    group.bench_with_input(
+        BenchmarkId::new(
+            "fill_existing_tensor",
+            name.to_owned() + "_" + std::any::type_name::<T>(),
+        ),
+        shape,
+        |b, shape| {
+            let mut t = alloc_tensor::<T>(shape.clone());
+            b.iter(|| {
+                t.view_mut()
+                    .as_slice_mut()
+                    .unwrap()
+                    .fill(fill_value.clone());
+            })
+        },
+    );
+}
+
+fn alloc_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Alloc");
+    // let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
+    // group.plot_config(plot_config);
+
+    for (name, shape) in [
+        // These sizes are selected to roughly provide exponential spacing across samples
+        // (spaced roughly ~16x apart because each item is tested with types between 1 byte and 8 bytes)
+        ("image", vec![1, 1200, 1920, 3]),
+        ("small_image", vec![1, 480, 320, 3]),
+        ("square", vec![160, 160]),
+        ("small", vec![5, 320]),
+        ("one_d", vec![100]),
+        ("tiny", vec![8]),
+    ]
+    .iter()
+    {
+        // NOTE: this only tests numeric types
+        for_each_numeric_carton_type! {
+            $(
+                typed_alloc_benchmark::<$RustType, _>(name, &mut group, shape, 1 as _);
+            )*
+        }
+    }
+    group.finish();
+}
+
+criterion_group!(benches, alloc_benchmark);
+criterion_main!(benches);

--- a/source/carton-runner-interface/benches/lines.svg
+++ b/source/carton-runner-interface/benches/lines.svg
@@ -1,0 +1,288 @@
+<svg width="960" height="540" viewBox="0 0 960 540" xmlns="http://www.w3.org/2000/svg">
+<text x="480" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="16.129032258064516" opacity="1" fill="#000000">
+Alloc: Comparison
+</text>
+<text x="26" y="263" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000" transform="rotate(270, 26, 263)">
+Average time (ms)
+</text>
+<text x="510" y="514" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+Input Size (Bytes)
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="85,52 85,473 "/>
+<text x="76" y="429" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+2.0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="80,429 85,429 "/>
+<text x="76" y="385" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+4.0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="80,385 85,385 "/>
+<text x="76" y="341" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+6.0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="80,341 85,341 "/>
+<text x="76" y="297" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+8.0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="80,297 85,297 "/>
+<text x="76" y="253" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+10.0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="80,253 85,253 "/>
+<text x="76" y="209" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+12.0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="80,209 85,209 "/>
+<text x="76" y="165" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+14.0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="80,165 85,165 "/>
+<text x="76" y="121" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+16.0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="80,121 85,121 "/>
+<text x="76" y="77" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+18.0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="80,77 85,77 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="86,474 933,474 "/>
+<text x="162" y="484" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+5000000.0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="162,474 162,479 "/>
+<text x="239" y="484" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+10000000.0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="239,474 239,479 "/>
+<text x="315" y="484" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+15000000.0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="315,474 315,479 "/>
+<text x="392" y="484" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+20000000.0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="392,474 392,479 "/>
+<text x="468" y="484" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+25000000.0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="468,474 468,479 "/>
+<text x="545" y="484" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+30000000.0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="545,474 545,479 "/>
+<text x="622" y="484" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+35000000.0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="622,474 622,479 "/>
+<text x="698" y="484" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+40000000.0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="698,474 698,479 "/>
+<text x="775" y="484" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+45000000.0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="775,474 775,479 "/>
+<text x="851" y="484" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+50000000.0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="851,474 851,479 "/>
+<text x="928" y="484" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+55000000.0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="928,474 928,479 "/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="87" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="87" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="87" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="89" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="89" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="89" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="93" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="93" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="100" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="100" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="114" cy="472" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="114" cy="472" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="114" cy="472" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="142" cy="471" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="142" cy="471" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="142" cy="471" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="191" cy="467" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="191" cy="468" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="297" cy="446" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="297" cy="449" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="509" cy="420" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="509" cy="418" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="509" cy="421" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="933" cy="367" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="933" cy="367" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="933" cy="368" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#B22222" stroke-width="1" points="86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 87,473 87,473 87,473 89,473 89,473 89,473 93,473 93,473 100,473 100,473 114,472 114,472 114,472 142,471 142,471 142,471 191,467 191,468 297,446 297,449 509,420 509,418 509,421 933,367 933,367 933,368 "/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="87" cy="473" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="87" cy="473" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="87" cy="473" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="89" cy="473" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="89" cy="473" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="89" cy="473" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="93" cy="473" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="93" cy="473" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="100" cy="473" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="100" cy="473" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="114" cy="472" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="114" cy="472" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="114" cy="472" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="142" cy="471" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="142" cy="471" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="142" cy="471" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="191" cy="467" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="191" cy="467" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="297" cy="448" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="297" cy="449" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="509" cy="421" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="509" cy="418" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="509" cy="421" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="933" cy="368" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="933" cy="368" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="933" cy="368" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#2E8B57" stroke-width="1" points="86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 87,473 87,473 87,473 89,473 89,473 89,473 93,473 93,473 100,473 100,473 114,472 114,472 114,472 142,471 142,471 142,471 191,467 191,467 297,448 297,449 509,421 509,418 509,421 933,368 933,368 933,368 "/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="87" cy="473" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="87" cy="473" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="87" cy="473" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="89" cy="473" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="89" cy="473" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="89" cy="473" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="93" cy="473" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="93" cy="473" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="100" cy="472" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="100" cy="472" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="114" cy="464" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="114" cy="466" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="114" cy="466" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="142" cy="437" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="142" cy="442" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="142" cy="442" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="191" cy="461" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="191" cy="462" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="297" cy="418" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="297" cy="418" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="509" cy="263" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="509" cy="261" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="509" cy="258" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="933" cy="76" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="933" cy="52" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="933" cy="62" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#008B8B" stroke-width="1" points="86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 86,473 87,473 87,473 87,473 89,473 89,473 89,473 93,473 93,473 100,472 100,472 114,464 114,466 114,466 142,437 142,442 142,442 191,461 191,462 297,418 297,418 509,263 509,261 509,258 933,76 933,52 933,62 "/>
+<text x="131" y="67" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+fill_existing_tensor
+</text>
+<text x="131" y="82" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+inline_storage_with_pool
+</text>
+<text x="131" y="97" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+inline_storage_without_pool
+</text>
+<rect x="101" y="67" width="20" height="10" opacity="1" fill="#B22222" stroke="none"/>
+<rect x="101" y="82" width="20" height="10" opacity="1" fill="#2E8B57" stroke="none"/>
+<rect x="101" y="97" width="20" height="10" opacity="1" fill="#008B8B" stroke="none"/>
+</svg>

--- a/source/carton-runner-interface/benches/lines_log.svg
+++ b/source/carton-runner-interface/benches/lines_log.svg
@@ -1,0 +1,260 @@
+<svg width="960" height="540" viewBox="0 0 960 540" xmlns="http://www.w3.org/2000/svg">
+<text x="480" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="16.129032258064516" opacity="1" fill="#000000">
+Alloc: Comparison
+</text>
+<text x="26" y="263" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000" transform="rotate(270, 26, 263)">
+Average time (ms)
+</text>
+<text x="510" y="514" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+Input Size (Bytes)
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="85,52 85,473 "/>
+<text x="76" y="450" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+0.0001
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="80,450 85,450 "/>
+<text x="76" y="375" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+0.001
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="80,375 85,375 "/>
+<text x="76" y="300" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+0.01
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="80,300 85,300 "/>
+<text x="76" y="225" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+0.1
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="80,225 85,225 "/>
+<text x="76" y="150" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+1.0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="80,150 85,150 "/>
+<text x="76" y="75" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+10.0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="80,75 85,75 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="86,474 933,474 "/>
+<text x="98" y="484" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+10.0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="98,474 98,479 "/>
+<text x="221" y="484" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+100.0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="221,474 221,479 "/>
+<text x="345" y="484" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+1000.0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="345,474 345,479 "/>
+<text x="469" y="484" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+10000.0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="469,474 469,479 "/>
+<text x="593" y="484" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+100000.0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="593,474 593,479 "/>
+<text x="717" y="484" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+1000000.0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="717,474 717,479 "/>
+<text x="841" y="484" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+10000000.0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="841,474 841,479 "/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="123" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="123" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="160" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="160" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="160" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="197" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="197" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="197" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="221" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="221" cy="473" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="259" cy="472" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="259" cy="472" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="296" cy="471" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="296" cy="470" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="296" cy="470" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="333" cy="467" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="333" cy="467" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="333" cy="467" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="370" cy="469" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="370" cy="469" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="408" cy="452" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="408" cy="452" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="445" cy="439" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="445" cy="439" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="445" cy="438" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="482" cy="420" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="482" cy="420" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="482" cy="420" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="520" cy="419" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="520" cy="420" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="557" cy="372" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="557" cy="373" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="594" cy="350" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="594" cy="350" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="594" cy="350" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="631" cy="327" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="631" cy="327" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="631" cy="327" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="675" cy="303" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="675" cy="304" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="712" cy="273" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="712" cy="272" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="750" cy="249" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="750" cy="250" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="750" cy="249" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="787" cy="216" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="787" cy="216" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="787" cy="216" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="821" cy="190" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="821" cy="192" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="858" cy="145" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="858" cy="145" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="895" cy="119" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="895" cy="121" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="895" cy="121" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="933" cy="97" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="933" cy="99" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<circle cx="933" cy="99" r="3" opacity="1" fill="#B22222" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#B22222" stroke-width="1" points="86,473 86,473 123,473 123,473 160,473 160,473 160,473 197,473 197,473 197,473 221,473 221,473 259,472 259,472 296,471 296,470 296,470 333,467 333,467 333,467 370,469 370,469 408,452 408,452 445,439 445,439 445,438 482,420 482,420 482,420 520,419 520,420 557,372 557,373 594,350 594,350 594,350 631,327 631,327 631,327 675,303 675,304 712,273 712,272 750,249 750,250 750,249 787,216 787,216 787,216 821,190 821,192 858,145 858,145 895,119 895,121 895,121 933,97 933,99 933,99 "/>
+<circle cx="86" cy="433" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="433" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="123" cy="433" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="123" cy="432" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="160" cy="433" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="160" cy="433" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="160" cy="433" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="197" cy="433" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="197" cy="432" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="197" cy="432" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="221" cy="433" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="221" cy="433" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="259" cy="432" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="259" cy="432" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="296" cy="431" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="296" cy="431" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="296" cy="431" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="333" cy="430" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="333" cy="430" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="333" cy="429" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="370" cy="431" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="370" cy="431" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="408" cy="424" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="408" cy="424" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="445" cy="418" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="445" cy="418" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="445" cy="417" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="482" cy="407" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="482" cy="407" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="482" cy="407" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="520" cy="406" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="520" cy="406" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="557" cy="369" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="557" cy="369" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="594" cy="348" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="594" cy="348" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="594" cy="349" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="631" cy="326" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="631" cy="326" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="631" cy="326" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="675" cy="304" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="675" cy="302" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="712" cy="273" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="712" cy="272" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="750" cy="249" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="750" cy="249" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="750" cy="248" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="787" cy="216" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="787" cy="211" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="787" cy="216" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="821" cy="191" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="821" cy="192" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="858" cy="144" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="858" cy="145" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="895" cy="122" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="895" cy="121" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="895" cy="121" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="933" cy="98" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="933" cy="99" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<circle cx="933" cy="98" r="3" opacity="1" fill="#2E8B57" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#2E8B57" stroke-width="1" points="86,433 86,433 123,433 123,432 160,433 160,433 160,433 197,433 197,432 197,432 221,433 221,433 259,432 259,432 296,431 296,431 296,431 333,430 333,430 333,429 370,431 370,431 408,424 408,424 445,418 445,418 445,417 482,407 482,407 482,407 520,406 520,406 557,369 557,369 594,348 594,348 594,349 631,326 631,326 631,326 675,304 675,302 712,273 712,272 750,249 750,249 750,248 787,216 787,211 787,216 821,191 821,192 858,144 858,145 895,122 895,121 895,121 933,98 933,99 933,98 "/>
+<circle cx="86" cy="443" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="86" cy="443" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="123" cy="447" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="123" cy="447" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="160" cy="442" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="160" cy="442" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="160" cy="442" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="197" cy="441" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="197" cy="441" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="197" cy="441" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="221" cy="447" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="221" cy="447" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="259" cy="441" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="259" cy="443" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="296" cy="437" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="296" cy="436" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="296" cy="438" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="333" cy="423" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="333" cy="428" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="333" cy="422" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="370" cy="438" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="370" cy="437" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="408" cy="419" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="408" cy="419" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="445" cy="392" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="445" cy="401" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="445" cy="401" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="482" cy="349" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="482" cy="355" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="482" cy="349" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="520" cy="381" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="520" cy="394" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="557" cy="343" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="557" cy="344" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="594" cy="303" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="594" cy="300" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="594" cy="301" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="631" cy="258" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="631" cy="258" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="631" cy="258" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="675" cy="283" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="675" cy="281" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="712" cy="240" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="712" cy="241" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="750" cy="177" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="750" cy="181" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="750" cy="177" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="787" cy="133" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="787" cy="133" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="787" cy="133" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="821" cy="169" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="821" cy="169" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="858" cy="120" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="858" cy="120" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="895" cy="75" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="895" cy="76" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="895" cy="76" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="933" cy="52" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="933" cy="53" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<circle cx="933" cy="53" r="3" opacity="1" fill="#008B8B" stroke="none" stroke-width="1"/>
+<polyline fill="none" opacity="1" stroke="#008B8B" stroke-width="1" points="86,443 86,443 123,447 123,447 160,442 160,442 160,442 197,441 197,441 197,441 221,447 221,447 259,441 259,443 296,437 296,436 296,438 333,423 333,428 333,422 370,438 370,437 408,419 408,419 445,392 445,401 445,401 482,349 482,355 482,349 520,381 520,394 557,343 557,344 594,303 594,300 594,301 631,258 631,258 631,258 675,283 675,281 712,240 712,241 750,177 750,181 750,177 787,133 787,133 787,133 821,169 821,169 858,120 858,120 895,75 895,76 895,76 933,52 933,53 933,53 "/>
+<text x="131" y="67" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+fill_existing_tensor
+</text>
+<text x="131" y="82" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+inline_storage_with_pool
+</text>
+<text x="131" y="97" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+inline_storage_without_pool
+</text>
+<rect x="101" y="67" width="20" height="10" opacity="1" fill="#B22222" stroke="none"/>
+<rect x="101" y="82" width="20" height="10" opacity="1" fill="#2E8B57" stroke="none"/>
+<rect x="101" y="97" width="20" height="10" opacity="1" fill="#008B8B" stroke="none"/>
+</svg>

--- a/source/carton-runner-interface/src/do_not_modify/alloc.rs
+++ b/source/carton-runner-interface/src/do_not_modify/alloc.rs
@@ -1,0 +1,128 @@
+use std::{
+    fmt::Debug,
+    ops::{Deref, DerefMut},
+    sync::Arc,
+};
+
+use carton_macros::for_each_numeric_carton_type;
+use serde::{Deserialize, Serialize};
+
+use super::alloc_pool::{AllocItem, PoolAllocator, PoolItem};
+
+/// Numeric tensor types supported by this version of the runner interface
+pub(crate) trait NumericTensorType: Default + Copy {}
+
+for_each_numeric_carton_type! {
+    $(
+        impl NumericTensorType for $RustType {}
+    )*
+}
+
+impl<T: Default + Clone> AllocItem for Vec<T> {
+    fn new(numel: usize) -> Self {
+        vec![T::default(); numel]
+    }
+
+    fn len(&self) -> usize {
+        self.len()
+    }
+}
+
+pub trait AsPtr<T> {
+    /// Get a view of this tensor
+    fn as_ptr(&self) -> *const T;
+
+    /// Get a mut view of this tensor
+    fn as_mut_ptr(&mut self) -> *mut T;
+}
+
+pub trait TypedAlloc<T> {
+    type Output: AsPtr<T>;
+
+    fn alloc(&self, numel: usize) -> Self::Output;
+}
+
+pub struct Allocator {
+    use_pool: bool,
+    numeric: Arc<PoolAllocator<Vec<u8>>>,
+    string: Arc<PoolAllocator<Vec<String>>>,
+}
+
+impl Allocator {
+    pub(crate) fn new() -> Self {
+        Self {
+            use_pool: true,
+            numeric: Arc::new(PoolAllocator::new()),
+            string: Arc::new(PoolAllocator::new()),
+        }
+    }
+
+    pub(crate) fn without_pool() -> Self {
+        Self {
+            use_pool: false,
+            numeric: Arc::new(PoolAllocator::new()),
+            string: Arc::new(PoolAllocator::new()),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum InlineTensorStorage {
+    Numeric(#[serde(with = "serde_bytes")] PoolItem<Vec<u8>>),
+    String(PoolItem<Vec<String>>),
+}
+
+impl<T> AsPtr<T> for InlineTensorStorage {
+    /// Get a view of this tensor
+    fn as_ptr(&self) -> *const T {
+        match self {
+            InlineTensorStorage::Numeric(s) => s.deref().as_ptr() as _,
+            // TODO: this should fail if T is not String. Figure out how to do that without specialization
+            InlineTensorStorage::String(s) => s.as_ptr() as _,
+        }
+    }
+
+    /// Get a mut view of this tensor
+    fn as_mut_ptr(&mut self) -> *mut T {
+        match self {
+            InlineTensorStorage::Numeric(s) => s.deref_mut().as_mut_ptr() as _,
+            // TODO: this should fail if T is not String. Figure out how to do that without specialization
+            InlineTensorStorage::String(s) => s.as_mut_ptr() as _,
+        }
+    }
+}
+
+for_each_numeric_carton_type! {
+    $(
+        /// We're using a macro here instead of a generic impl because rust gives misleading error messages otherwise.
+        impl TypedAlloc<$RustType> for Allocator {
+            type Output = InlineTensorStorage;
+
+            fn alloc(&self, numel: usize) -> Self::Output {
+                // We need to convert to size_bytes since we always use a Vec<u8>
+                let size_bytes = numel * std::mem::size_of::<$RustType>();
+                let out = if !self.use_pool {
+                    vec![0u8; size_bytes].into()
+                } else {
+                    self.numeric.alloc(size_bytes)
+                };
+
+                InlineTensorStorage::Numeric(out)
+            }
+        }
+    )*
+}
+
+impl TypedAlloc<String> for Allocator {
+    type Output = InlineTensorStorage;
+
+    fn alloc(&self, numel: usize) -> Self::Output {
+        let out = if !self.use_pool {
+            vec![String::default(); numel].into()
+        } else {
+            self.string.alloc(numel)
+        };
+
+        InlineTensorStorage::String(out)
+    }
+}

--- a/source/carton-runner-interface/src/do_not_modify/alloc_pool.rs
+++ b/source/carton-runner-interface/src/do_not_modify/alloc_pool.rs
@@ -1,0 +1,126 @@
+//! A reuse pool for allocators
+
+use std::{
+    ops::{Deref, DerefMut},
+    sync::{Arc, Weak},
+};
+
+use dashmap::DashMap;
+use serde::{Deserialize, Serialize};
+
+/// The item wrapper handed out by the pool
+/// IMPORTANT: changing this type can affect the wire protocol. Be careful
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct PoolItem<T: AllocItem> {
+    #[serde(skip)]
+    allocator: Option<Weak<PoolAllocator<T>>>,
+
+    inner: Option<T>,
+}
+
+impl serde_bytes::Serialize for PoolItem<Vec<u8>> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serde_bytes::Serialize::serialize(&self.inner, serializer)
+    }
+}
+
+impl<'de> serde_bytes::Deserialize<'de> for PoolItem<Vec<u8>> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(Self {
+            allocator: None,
+            inner: serde_bytes::Deserialize::deserialize(deserializer)?,
+        })
+    }
+}
+
+/// Convenience method to convert into a PoolItem with no pool
+/// Useful in tests and benchmarks
+impl<T: AllocItem> From<T> for PoolItem<T> {
+    fn from(value: T) -> Self {
+        Self {
+            allocator: None,
+            inner: Some(value),
+        }
+    }
+}
+
+/// Return the inner item to the pool if we have one and the pool still exists
+impl<T: AllocItem> Drop for PoolItem<T> {
+    fn drop(&mut self) {
+        self.allocator.as_ref().map(|weak| {
+            weak.upgrade()
+                .map(|alloc| alloc.return_for_reuse(self.inner.take().unwrap()))
+        });
+    }
+}
+
+impl<T: AllocItem> Deref for PoolItem<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.inner.as_ref().unwrap()
+    }
+}
+
+impl<T: AllocItem> DerefMut for PoolItem<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.inner.as_mut().unwrap()
+    }
+}
+
+/// An item that can be allocated
+pub trait AllocItem {
+    fn new(numel: usize) -> Self;
+
+    /// This MUST return the same value as `numel` passed into `new` above
+    fn len(&self) -> usize;
+}
+
+/// Allocates `T: AllocItem` and attempts to reuse previously allocated and dropped items.
+#[derive(Debug)]
+pub(crate) struct PoolAllocator<T> {
+    // TODO: handle cache eviction every once in a while
+    /// A map of items that can be reused
+    reusable: DashMap<usize, Vec<T>>,
+}
+
+impl<T: AllocItem> PoolAllocator<T> {
+    pub(crate) fn new() -> Self {
+        Self {
+            reusable: Default::default(),
+        }
+    }
+
+    /// Allocate a `T`. Tries to reuse previous allocations if possible.
+    pub(crate) fn alloc(self: &Arc<Self>, numel: usize) -> PoolItem<T> {
+        // Check if we can reuse something that was previously allocated
+        if let Some(mut reusable) = self.reusable.get_mut(&numel) {
+            // Pop the last element. This makes an lru strategy work better because the front of the vec is
+            // not touched unless it needs to be
+            if let Some(item) = reusable.pop() {
+                return PoolItem {
+                    allocator: Some(Arc::downgrade(self)),
+                    inner: Some(item),
+                };
+            }
+        }
+
+        // We need to allocate
+        let item = T::new(numel);
+        return PoolItem {
+            allocator: Some(Arc::downgrade(self)),
+            inner: Some(item),
+        };
+    }
+
+    fn return_for_reuse(&self, item: T) {
+        self.reusable.entry(item.len()).or_default().push(item)
+    }
+}

--- a/source/carton-runner-interface/src/do_not_modify/mod.rs
+++ b/source/carton-runner-interface/src/do_not_modify/mod.rs
@@ -1,5 +1,7 @@
+pub(crate) mod alloc;
+mod alloc_pool;
 mod framed;
-pub(crate) mod inline_storage;
+pub(crate) mod storage;
 pub mod types;
 
 if_not_wasm! {

--- a/source/carton-runner-interface/src/do_not_modify/types.rs
+++ b/source/carton-runner-interface/src/do_not_modify/types.rs
@@ -2,7 +2,7 @@ pub use carton_macros::for_each_carton_type;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, marker::PhantomData};
 
-use super::comms::Comms;
+use super::{alloc::InlineTensorStorage, comms::Comms};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RPCRequest {
@@ -173,7 +173,7 @@ for_each_carton_type! {
     }
 }
 
-pub type TensorStorage<T> = super::inline_storage::TensorStorage<T>;
+pub type TensorStorage<T> = super::storage::TensorStorage<T, InlineTensorStorage>;
 
 for_each_carton_type! {
     $(

--- a/source/carton-runner-interface/src/lib.rs
+++ b/source/carton-runner-interface/src/lib.rs
@@ -21,7 +21,7 @@ macro_rules! if_not_wasm {
 mod client;
 mod do_not_modify;
 mod multiplexer;
-mod runner;
+pub mod runner;
 
 if_not_wasm! {
     pub mod server;
@@ -44,3 +44,9 @@ if_wasm! {
 
 pub use do_not_modify::types;
 pub use runner::Runner;
+
+#[cfg(feature = "benchmark")]
+pub mod _only_public_for_benchmarks_do_not_use {
+    pub use crate::do_not_modify::alloc::{Allocator, InlineTensorStorage, TypedAlloc};
+    pub use crate::do_not_modify::storage::{alloc_tensor, alloc_tensor_no_pool};
+}

--- a/source/carton-runner-interface/src/runner.rs
+++ b/source/carton-runner-interface/src/runner.rs
@@ -3,7 +3,10 @@ use std::{collections::HashMap, sync::Arc};
 use crate::{
     client::Client,
     do_not_modify::comms::OwnedComms,
-    do_not_modify::types::{Device, RPCRequestData, RPCResponseData, SealHandle, Tensor},
+    do_not_modify::{
+        alloc::{Allocator, InlineTensorStorage, TypedAlloc},
+        types::{Device, RPCRequestData, RPCResponseData, SealHandle, Tensor},
+    },
     types::{Handle, RunnerOpt, TensorStorage},
 };
 
@@ -202,9 +205,10 @@ impl Runner {
 
     pub async fn alloc_tensor<T: Clone + Default>(&self, shape: Vec<u64>) -> Result<Tensor, String>
     where
+        Allocator: TypedAlloc<T, Output = InlineTensorStorage>,
         Tensor: From<TensorStorage<T>>,
     {
-        Ok(crate::do_not_modify::inline_storage::alloc_tensor::<T>(shape).into())
+        Ok(crate::do_not_modify::storage::alloc_tensor(shape).into())
     }
 
     // pub async fn infer_with_handle(


### PR DESCRIPTION
This PR implements an allocator that reuses previously allocated and dropped allocations. This significantly improves performance for large tensors.

See the benchmark and analysis in `source/carton-runner-interface/benches`