### PR TITLE
Refactor allocator code to extract inline allocation

### DIFF
--- a/source/carton-runner-interface/benches/bench_alloc.rs
+++ b/source/carton-runner-interface/benches/bench_alloc.rs
@@ -1,7 +1,7 @@
 //! This benchmark measures tensor allocation overhead
 use carton_macros::for_each_numeric_carton_type;
 use carton_runner_interface::_only_public_for_benchmarks_do_not_use::{
-    alloc_tensor, alloc_tensor_no_pool, Allocator, InlineTensorStorage, TypedAlloc,
+    alloc_tensor, alloc_tensor_no_pool, InlineAllocator, InlineTensorStorage, TypedAlloc,
 };
 use criterion::{
     criterion_group, criterion_main, measurement::Measurement, AxisScale, BenchmarkGroup,
@@ -16,7 +16,7 @@ fn typed_alloc_benchmark<T: Clone + Default, U: Measurement>(
     shape: &Vec<u64>,
     fill_value: T,
 ) where
-    Allocator: TypedAlloc<T, Output = InlineTensorStorage>,
+    InlineAllocator: TypedAlloc<T, Output = InlineTensorStorage>,
 {
     let numel = shape.iter().product::<u64>();
     let size_bytes = std::mem::size_of::<T>() as u64 * numel;

--- a/source/carton-runner-interface/src/do_not_modify/alloc.rs
+++ b/source/carton-runner-interface/src/do_not_modify/alloc.rs
@@ -7,7 +7,7 @@ use std::{
 use carton_macros::for_each_numeric_carton_type;
 use serde::{Deserialize, Serialize};
 
-use super::alloc_pool::{AllocItem, PoolAllocator, PoolItem};
+use super::alloc_pool::{PoolAllocator, PoolItem};
 
 /// Numeric tensor types supported by this version of the runner interface
 pub(crate) trait NumericTensorType: Default + Copy {}
@@ -16,16 +16,6 @@ for_each_numeric_carton_type! {
     $(
         impl NumericTensorType for $RustType {}
     )*
-}
-
-impl<T: Default + Clone> AllocItem for Vec<T> {
-    fn new(numel: usize) -> Self {
-        vec![T::default(); numel]
-    }
-
-    fn len(&self) -> usize {
-        self.len()
-    }
 }
 
 pub trait AsPtr<T> {
@@ -40,89 +30,4 @@ pub trait TypedAlloc<T> {
     type Output: AsPtr<T>;
 
     fn alloc(&self, numel: usize) -> Self::Output;
-}
-
-pub struct Allocator {
-    use_pool: bool,
-    numeric: Arc<PoolAllocator<Vec<u8>>>,
-    string: Arc<PoolAllocator<Vec<String>>>,
-}
-
-impl Allocator {
-    pub(crate) fn new() -> Self {
-        Self {
-            use_pool: true,
-            numeric: Arc::new(PoolAllocator::new()),
-            string: Arc::new(PoolAllocator::new()),
-        }
-    }
-
-    pub(crate) fn without_pool() -> Self {
-        Self {
-            use_pool: false,
-            numeric: Arc::new(PoolAllocator::new()),
-            string: Arc::new(PoolAllocator::new()),
-        }
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub enum InlineTensorStorage {
-    Numeric(#[serde(with = "serde_bytes")] PoolItem<Vec<u8>>),
-    String(PoolItem<Vec<String>>),
-}
-
-impl<T> AsPtr<T> for InlineTensorStorage {
-    /// Get a view of this tensor
-    fn as_ptr(&self) -> *const T {
-        match self {
-            InlineTensorStorage::Numeric(s) => s.deref().as_ptr() as _,
-            // TODO: this should fail if T is not String. Figure out how to do that without specialization
-            InlineTensorStorage::String(s) => s.as_ptr() as _,
-        }
-    }
-
-    /// Get a mut view of this tensor
-    fn as_mut_ptr(&mut self) -> *mut T {
-        match self {
-            InlineTensorStorage::Numeric(s) => s.deref_mut().as_mut_ptr() as _,
-            // TODO: this should fail if T is not String. Figure out how to do that without specialization
-            InlineTensorStorage::String(s) => s.as_mut_ptr() as _,
-        }
-    }
-}
-
-for_each_numeric_carton_type! {
-    $(
-        /// We're using a macro here instead of a generic impl because rust gives misleading error messages otherwise.
-        impl TypedAlloc<$RustType> for Allocator {
-            type Output = InlineTensorStorage;
-
-            fn alloc(&self, numel: usize) -> Self::Output {
-                // We need to convert to size_bytes since we always use a Vec<u8>
-                let size_bytes = numel * std::mem::size_of::<$RustType>();
-                let out = if !self.use_pool {
-                    vec![0u8; size_bytes].into()
-                } else {
-                    self.numeric.alloc(size_bytes)
-                };
-
-                InlineTensorStorage::Numeric(out)
-            }
-        }
-    )*
-}
-
-impl TypedAlloc<String> for Allocator {
-    type Output = InlineTensorStorage;
-
-    fn alloc(&self, numel: usize) -> Self::Output {
-        let out = if !self.use_pool {
-            vec![String::default(); numel].into()
-        } else {
-            self.string.alloc(numel)
-        };
-
-        InlineTensorStorage::String(out)
-    }
 }

--- a/source/carton-runner-interface/src/do_not_modify/alloc_inline.rs
+++ b/source/carton-runner-interface/src/do_not_modify/alloc_inline.rs
@@ -1,0 +1,175 @@
+use std::{
+    marker::PhantomData,
+    ops::{Deref, DerefMut},
+    sync::Arc,
+};
+
+use carton_macros::for_each_numeric_carton_type;
+use once_cell::sync::Lazy;
+use serde::{Deserialize, Serialize};
+
+use super::{
+    alloc::{AsPtr, NumericTensorType, TypedAlloc},
+    alloc_pool::{PoolAllocator, PoolItem},
+    storage::TensorStorage,
+};
+
+pub struct InlineAllocator {
+    use_pool: bool,
+    numeric: Arc<PoolAllocator<Vec<u8>>>,
+    string: Arc<PoolAllocator<Vec<String>>>,
+}
+
+impl InlineAllocator {
+    pub(crate) fn new() -> Self {
+        Self {
+            use_pool: true,
+            numeric: Arc::new(PoolAllocator::new()),
+            string: Arc::new(PoolAllocator::new()),
+        }
+    }
+
+    pub(crate) fn without_pool() -> Self {
+        Self {
+            use_pool: false,
+            numeric: Arc::new(PoolAllocator::new()),
+            string: Arc::new(PoolAllocator::new()),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum InlineTensorStorage {
+    Numeric(#[serde(with = "serde_bytes")] PoolItem<Vec<u8>>),
+    String(PoolItem<Vec<String>>),
+}
+
+impl<T> AsPtr<T> for InlineTensorStorage {
+    /// Get a view of this tensor
+    fn as_ptr(&self) -> *const T {
+        match self {
+            InlineTensorStorage::Numeric(s) => s.deref().as_ptr() as _,
+            // TODO: this should fail if T is not String. Figure out how to do that without specialization
+            InlineTensorStorage::String(s) => s.as_ptr() as _,
+        }
+    }
+
+    /// Get a mut view of this tensor
+    fn as_mut_ptr(&mut self) -> *mut T {
+        match self {
+            InlineTensorStorage::Numeric(s) => s.deref_mut().as_mut_ptr() as _,
+            // TODO: this should fail if T is not String. Figure out how to do that without specialization
+            InlineTensorStorage::String(s) => s.as_mut_ptr() as _,
+        }
+    }
+}
+
+for_each_numeric_carton_type! {
+    $(
+        /// We're using a macro here instead of a generic impl because rust gives misleading error messages otherwise.
+        impl TypedAlloc<$RustType> for InlineAllocator {
+            type Output = InlineTensorStorage;
+
+            fn alloc(&self, numel: usize) -> Self::Output {
+                // We need to convert to size_bytes since we always use a Vec<u8>
+                let size_bytes = numel * std::mem::size_of::<$RustType>();
+                let out = if !self.use_pool {
+                    vec![0u8; size_bytes].into()
+                } else {
+                    self.numeric.alloc(size_bytes)
+                };
+
+                InlineTensorStorage::Numeric(out)
+            }
+        }
+    )*
+}
+
+impl TypedAlloc<String> for InlineAllocator {
+    type Output = InlineTensorStorage;
+
+    fn alloc(&self, numel: usize) -> Self::Output {
+        let out = if !self.use_pool {
+            vec![String::default(); numel].into()
+        } else {
+            self.string.alloc(numel)
+        };
+
+        InlineTensorStorage::String(out)
+    }
+}
+
+// Copy the data
+impl<T: NumericTensorType + Default + Copy> From<ndarray::ArrayViewD<'_, T>>
+    for TensorStorage<T, InlineTensorStorage>
+where
+    InlineAllocator: TypedAlloc<T, Output = InlineTensorStorage>,
+{
+    fn from(view: ndarray::ArrayViewD<'_, T>) -> Self {
+        // Alloc a tensor
+        let mut out = alloc_tensor(view.shape().iter().map(|v| (*v) as _).collect());
+
+        if view.is_standard_layout() {
+            // We can just memcpy the data
+            out.view_mut()
+                .as_slice_mut()
+                .unwrap()
+                .copy_from_slice(view.as_slice().unwrap())
+        } else {
+            out.view_mut().assign(&view);
+        }
+
+        out
+    }
+}
+
+impl From<ndarray::ArrayViewD<'_, String>> for TensorStorage<String, InlineTensorStorage> {
+    fn from(view: ndarray::ArrayViewD<'_, String>) -> Self {
+        // Alloc a tensor
+        let mut out = alloc_tensor(view.shape().iter().map(|v| (*v) as _).collect());
+
+        // Can't memcpy
+        out.view_mut().assign(&view);
+
+        out
+    }
+}
+
+// Allocates a contiguous tensor with a shape and type
+pub fn alloc_tensor_no_pool<T: Default + Clone>(
+    shape: Vec<u64>,
+) -> TensorStorage<T, InlineTensorStorage>
+where
+    InlineAllocator: TypedAlloc<T, Output = InlineTensorStorage>,
+{
+    static POOL_ALLOCATOR: Lazy<InlineAllocator> = Lazy::new(|| InlineAllocator::without_pool());
+
+    let numel = shape.iter().product::<u64>() as usize;
+
+    let data = POOL_ALLOCATOR.alloc(numel);
+
+    TensorStorage {
+        data,
+        shape,
+        strides: None,
+        pd: PhantomData,
+    }
+}
+
+pub fn alloc_tensor<T: Default + Clone>(shape: Vec<u64>) -> TensorStorage<T, InlineTensorStorage>
+where
+    InlineAllocator: TypedAlloc<T, Output = InlineTensorStorage>,
+{
+    static POOL_ALLOCATOR: Lazy<InlineAllocator> = Lazy::new(|| InlineAllocator::new());
+
+    let numel = shape.iter().product::<u64>() as usize;
+
+    let data = POOL_ALLOCATOR.alloc(numel);
+
+    TensorStorage {
+        data,
+        shape,
+        strides: None,
+        pd: PhantomData,
+    }
+}

--- a/source/carton-runner-interface/src/do_not_modify/alloc_pool.rs
+++ b/source/carton-runner-interface/src/do_not_modify/alloc_pool.rs
@@ -83,6 +83,16 @@ pub trait AllocItem {
     fn len(&self) -> usize;
 }
 
+impl<T: Default + Clone> AllocItem for Vec<T> {
+    fn new(numel: usize) -> Self {
+        vec![T::default(); numel]
+    }
+
+    fn len(&self) -> usize {
+        self.len()
+    }
+}
+
 /// Allocates `T: AllocItem` and attempts to reuse previously allocated and dropped items.
 #[derive(Debug)]
 pub(crate) struct PoolAllocator<T> {

--- a/source/carton-runner-interface/src/do_not_modify/mod.rs
+++ b/source/carton-runner-interface/src/do_not_modify/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod alloc;
+pub(crate) mod alloc_inline;
 mod alloc_pool;
 mod framed;
 pub(crate) mod storage;

--- a/source/carton-runner-interface/src/do_not_modify/storage.rs
+++ b/source/carton-runner-interface/src/do_not_modify/storage.rs
@@ -3,17 +3,16 @@
 use std::{fmt::Debug, marker::PhantomData};
 
 use ndarray::{ShapeBuilder, StrideShape};
-use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 
-use super::alloc::{Allocator, AsPtr, InlineTensorStorage, NumericTensorType, TypedAlloc};
+use super::alloc::AsPtr;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct TensorStorage<T, Storage> {
-    data: Storage,
-    shape: Vec<u64>,
-    strides: Option<Vec<u64>>,
-    pd: PhantomData<T>,
+    pub(crate) data: Storage,
+    pub(crate) shape: Vec<u64>,
+    pub(crate) strides: Option<Vec<u64>>,
+    pub(crate) pd: PhantomData<T>,
 }
 
 impl<T, Storage> TensorStorage<T, Storage>
@@ -46,80 +45,5 @@ where
     pub fn view_mut(&mut self) -> ndarray::ArrayViewMutD<T> {
         let data = self.data.as_mut_ptr();
         unsafe { ndarray::ArrayViewMut::from_shape_ptr(self.get_shape(), data) }
-    }
-}
-
-// Copy the data
-impl<T: NumericTensorType + Default + Copy> From<ndarray::ArrayViewD<'_, T>>
-    for TensorStorage<T, InlineTensorStorage>
-where
-    Allocator: TypedAlloc<T, Output = InlineTensorStorage>,
-{
-    fn from(view: ndarray::ArrayViewD<'_, T>) -> Self {
-        // Alloc a tensor
-        let mut out = alloc_tensor(view.shape().iter().map(|v| (*v) as _).collect());
-
-        if view.is_standard_layout() {
-            // We can just memcpy the data
-            out.view_mut()
-                .as_slice_mut()
-                .unwrap()
-                .copy_from_slice(view.as_slice().unwrap())
-        } else {
-            out.view_mut().assign(&view);
-        }
-
-        out
-    }
-}
-
-impl From<ndarray::ArrayViewD<'_, String>> for TensorStorage<String, InlineTensorStorage> {
-    fn from(view: ndarray::ArrayViewD<'_, String>) -> Self {
-        // Alloc a tensor
-        let mut out = alloc_tensor(view.shape().iter().map(|v| (*v) as _).collect());
-
-        // Can't memcpy
-        out.view_mut().assign(&view);
-
-        out
-    }
-}
-
-// Allocates a contiguous tensor with a shape and type
-pub fn alloc_tensor_no_pool<T: Default + Clone>(
-    shape: Vec<u64>,
-) -> TensorStorage<T, InlineTensorStorage>
-where
-    Allocator: TypedAlloc<T, Output = InlineTensorStorage>,
-{
-    static POOL_ALLOCATOR: Lazy<Allocator> = Lazy::new(|| Allocator::without_pool());
-
-    let numel = shape.iter().product::<u64>() as usize;
-
-    let data = POOL_ALLOCATOR.alloc(numel);
-
-    TensorStorage {
-        data,
-        shape,
-        strides: None,
-        pd: PhantomData,
-    }
-}
-
-pub fn alloc_tensor<T: Default + Clone>(shape: Vec<u64>) -> TensorStorage<T, InlineTensorStorage>
-where
-    Allocator: TypedAlloc<T, Output = InlineTensorStorage>,
-{
-    static POOL_ALLOCATOR: Lazy<Allocator> = Lazy::new(|| Allocator::new());
-
-    let numel = shape.iter().product::<u64>() as usize;
-
-    let data = POOL_ALLOCATOR.alloc(numel);
-
-    TensorStorage {
-        data,
-        shape,
-        strides: None,
-        pd: PhantomData,
     }
 }

--- a/source/carton-runner-interface/src/do_not_modify/types.rs
+++ b/source/carton-runner-interface/src/do_not_modify/types.rs
@@ -2,7 +2,7 @@ pub use carton_macros::for_each_carton_type;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, marker::PhantomData};
 
-use super::{alloc::InlineTensorStorage, comms::Comms};
+use super::{alloc_inline::InlineTensorStorage, comms::Comms};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RPCRequest {

--- a/source/carton-runner-interface/src/lib.rs
+++ b/source/carton-runner-interface/src/lib.rs
@@ -47,6 +47,8 @@ pub use runner::Runner;
 
 #[cfg(feature = "benchmark")]
 pub mod _only_public_for_benchmarks_do_not_use {
-    pub use crate::do_not_modify::alloc::{Allocator, InlineTensorStorage, TypedAlloc};
-    pub use crate::do_not_modify::storage::{alloc_tensor, alloc_tensor_no_pool};
+    pub use crate::do_not_modify::alloc::TypedAlloc;
+    pub use crate::do_not_modify::alloc_inline::{
+        alloc_tensor, alloc_tensor_no_pool, InlineAllocator, InlineTensorStorage,
+    };
 }

--- a/source/carton-runner-interface/src/runner.rs
+++ b/source/carton-runner-interface/src/runner.rs
@@ -4,7 +4,8 @@ use crate::{
     client::Client,
     do_not_modify::comms::OwnedComms,
     do_not_modify::{
-        alloc::{Allocator, InlineTensorStorage, TypedAlloc},
+        alloc::TypedAlloc,
+        alloc_inline::{InlineAllocator, InlineTensorStorage},
         types::{Device, RPCRequestData, RPCResponseData, SealHandle, Tensor},
     },
     types::{Handle, RunnerOpt, TensorStorage},
@@ -205,10 +206,10 @@ impl Runner {
 
     pub async fn alloc_tensor<T: Clone + Default>(&self, shape: Vec<u64>) -> Result<Tensor, String>
     where
-        Allocator: TypedAlloc<T, Output = InlineTensorStorage>,
+        InlineAllocator: TypedAlloc<T, Output = InlineTensorStorage>,
         Tensor: From<TensorStorage<T>>,
     {
-        Ok(crate::do_not_modify::storage::alloc_tensor(shape).into())
+        Ok(crate::do_not_modify::alloc_inline::alloc_tensor(shape).into())
     }
 
     // pub async fn infer_with_handle(


### PR DESCRIPTION
In preparation for shared memory, this PR refactors `carton-runner-interface` to separate out inline allocation logic.