### PR TITLE
Create `carton-runner-py` containing basic wheel installation code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,11 +64,13 @@ version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "942c7cd7ae39e91bde4820d74132e9862e62c2f386c3aa90ccf55949f5bad63a"
 dependencies = [
+ "bzip2",
  "flate2",
  "futures-core",
  "memchr",
  "pin-project-lite",
  "tokio",
+ "xz2",
  "zstd",
  "zstd-safe",
 ]
@@ -232,6 +234,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 
 [[package]]
+name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "carton"
 version = "0.1.0"
 dependencies = [
@@ -325,6 +348,31 @@ version = "0.1.0"
 dependencies = [
  "carton-runner-interface",
  "tokio",
+]
+
+[[package]]
+name = "carton-runner-py"
+version = "0.0.1"
+dependencies = [
+ "async_zip",
+ "carton-runner-interface",
+ "home",
+ "lazy_static",
+ "libc",
+ "log",
+ "ndarray",
+ "numpy",
+ "path-clean",
+ "pyo3",
+ "pyo3-asyncio",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tempfile",
+ "tokio",
+ "toml",
+ "url",
 ]
 
 [[package]]
@@ -998,6 +1046,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "747309b4b440c06d57b0b25f2aee03ee9b5e5397d288c60e21fc709bb98a7408"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "http"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1296,6 +1353,17 @@ dependencies = [
  "serde",
  "thiserror",
  "tokio",
+]
+
+[[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -2960,6 +3028,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,6 @@ members = [
     "source/carton-bindings-nodejs",
     "source/carton-macros",
     "source/carton-runner-noop",
+    "source/carton-runner-py",
     "source/anywhere",
 ]

--- a/source/carton-bindings-py/Cargo.toml
+++ b/source/carton-bindings-py/Cargo.toml
@@ -8,7 +8,7 @@ name = "carton"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.17.3", features = ["extension-module"] }
+pyo3 = { version = "0.17.3" }
 pyo3-asyncio = { version = "0.17", features = ["attributes", "tokio-runtime"] }
 carton-core = { package = "carton", path = "../carton" }
 numpy = "0.17"

--- a/source/carton-bindings-py/pyproject.toml
+++ b/source/carton-bindings-py/pyproject.toml
@@ -8,3 +8,6 @@ requires-python = ">=3.7"
 
 [tool.maturin]
 python-source = "python"
+
+# See https://pyo3.rs/main/faq#i-cant-run-cargo-test-or-i-cant-build-in-a-cargo-workspace-im-having-linker-issues-like-symbol-not-found-or-undefined-reference-to-_pyexc_systemerror
+features = ["pyo3/extension-module"]

--- a/source/carton-runner-py/Cargo.toml
+++ b/source/carton-runner-py/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "carton-runner-py"
+version = "0.0.1"
+edition = "2021"
+
+[dependencies]
+carton-runner-interface = { path = "../carton-runner-interface" }
+tokio = { version = "1", features = ["full"] }
+pyo3 = { version = "0.17.3", features = ["auto-initialize"]}
+pyo3-asyncio = { version = "0.17", features = ["attributes", "tokio-runtime"] }
+numpy = "0.17"
+ndarray = { version = "0.15" }
+lazy_static = "1.4.0"
+reqwest = { version = "0.11" }
+tempfile = "3.3.0"
+home = "0.5.4"
+sha2 = "0.10.6"
+async_zip = {version = "0.0.11", features = ["full"]}
+path-clean = "0.1.0"
+toml = "0.5"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1"
+url = "2.3.1"
+log = "0.4"
+libc = "0.2"

--- a/source/carton-runner-py/src/main.rs
+++ b/source/carton-runner-py/src/main.rs
@@ -1,0 +1,4 @@
+mod python_utils;
+mod wheel;
+
+fn main() {}

--- a/source/carton-runner-py/src/python_utils.rs
+++ b/source/carton-runner-py/src/python_utils.rs
@@ -1,0 +1,36 @@
+use std::{ffi::OsStr, path::Path};
+
+use pyo3::{PyResult, Python};
+
+pub(crate) fn get_executable_path() -> PyResult<String> {
+    Python::with_gil(|py| Python::import(py, "sys")?.getattr("executable")?.extract())
+}
+
+/// Adds a vec of paths to sys.path
+/// Also updates the PYTHONPATH env var
+pub(crate) fn add_to_sys_path<P: AsRef<Path>>(paths: &Vec<P>) -> pyo3::PyResult<()> {
+    Python::with_gil(|py| {
+        let sys_path_insert = Python::import(py, "sys")?
+            .getattr("path")?
+            .getattr("insert")?;
+
+        for item in paths {
+            sys_path_insert.call1((0, item.as_ref()))?;
+        }
+
+        // TODO: PYTHONPATH is not inserted at the beginning of sys.path in new processes. This might cause
+        // problems if a package we want to use is also available in the built in installation
+        let to_add = paths
+            .into_iter()
+            .map(|p| p.as_ref().as_os_str())
+            .collect::<Vec<_>>()
+            .join(OsStr::new(":"));
+
+        // There's a race condition between reading and writing PYTHONPATH, but it shouldn't generally matter
+        let new_path =
+            to_add.into_string().unwrap() + ":" + &std::env::var("PYTHONPATH").unwrap_or_default();
+        std::env::set_var("PYTHONPATH", new_path);
+
+        Ok(())
+    })
+}

--- a/source/carton-runner-py/src/wheel.rs
+++ b/source/carton-runner-py/src/wheel.rs
@@ -1,0 +1,188 @@
+use std::path::{Path, PathBuf};
+
+use async_zip::read::fs::ZipFileReader;
+use lazy_static::lazy_static;
+use path_clean::PathClean;
+use pyo3::Python;
+use sha2::{Digest, Sha256};
+
+use crate::python_utils::add_to_sys_path;
+
+lazy_static! {
+    static ref PACKAGE_BASE_DIR: PathBuf = Python::with_gil(|py| {
+        let info = py.version_info();
+
+        let base = home::home_dir().unwrap().join(format!(
+            ".carton/pythonpackages/py{}{}/",
+            info.major, info.minor
+        ));
+
+        std::fs::create_dir_all(&base).unwrap();
+
+        base
+    });
+    static ref CLIENT: reqwest::Client = reqwest::Client::new();
+}
+
+/// Installs a wheel (if not already installed) and adds it to `sys.path`
+pub async fn install_wheel_and_make_available(url: &str, sha256: &str) {
+    let path = install_wheel(url, sha256).await;
+    add_to_sys_path(&vec![path]).unwrap();
+}
+
+/// Installs a wheel file (if not already installed) and returns the path to add to `sys.path`
+///
+/// See the wheel spec at https://packaging.python.org/en/latest/specifications/binary-distribution-format/
+/// There's a bit more to it, but a basic install just unzips the file into the target directory
+pub async fn install_wheel(url: &str, sha256: &str) -> PathBuf {
+    let target_dir = PACKAGE_BASE_DIR.join(sha256);
+    if target_dir.exists() {
+        // This already exists
+        // TODO: we should probably do some locking to avoid wasted parallel installations
+        return target_dir;
+    }
+
+    // Create a temp dir
+    let tempdir = tempfile::tempdir().unwrap();
+    let download_path = tempdir.path().join("download");
+
+    let mut outfile = tokio::fs::File::create(&download_path).await.unwrap();
+
+    // Download and copy to the target file while computing the sha256
+    let mut hasher = Sha256::new();
+    let mut res = CLIENT.get(url).send().await.unwrap();
+    while let Some(chunk) = res.chunk().await.unwrap() {
+        hasher.update(&chunk);
+        tokio::io::copy(&mut chunk.as_ref(), &mut outfile)
+            .await
+            .unwrap();
+    }
+
+    // Make sure the sha256 matches the expected value
+    let actual_sha256 = format!("{:x}", hasher.finalize());
+
+    // TODO: return an error instead of asserting
+    assert_eq!(sha256, actual_sha256);
+
+    // Unzip
+    let extraction_dir = tempdir.path().join("extraction");
+    unzip_file(&download_path, &extraction_dir).await;
+
+    // Move to the target directory. This should be atomic so it won't break anything
+    // if multiple installs happen at the same time.
+    match tokio::fs::rename(extraction_dir, &target_dir).await {
+        Err(e) if e.raw_os_error() == Some(libc::ENOTEMPTY) => {
+            // This can happen if another installation created the target directory before we called
+            // rename.
+            // We don't need to do anything here
+        }
+        e => e.unwrap(),
+    }
+
+    // Return the path to add to sys.path
+    target_dir
+}
+
+pub async fn activate_bundled_wheel(url: &str) {
+    // Unzip into a user-specified temp dir
+
+    // Return the path to add to sys.path
+}
+
+// Based on https://github.com/Majored/rs-async-zip/blob/main/examples/file_extraction.rs
+/// Extracts everything from the ZIP archive to the output directory
+async fn unzip_file(archive: &Path, out_dir: &Path) {
+    let reader = ZipFileReader::new(archive)
+        .await
+        .expect("Failed to read zip file");
+    for index in 0..reader.file().entries().len() {
+        let entry = &reader.file().entries().get(index).unwrap().entry();
+
+        // Normalize the file path
+        let path = out_dir.join(entry.filename()).clean();
+
+        // Ensure that path is within the base dir
+        if !path.starts_with(out_dir) {
+            panic!("Error: extracted file path does not start with the output dir")
+        }
+
+        // If the filename of the entry ends with '/', it is treated as a directory.
+        // This is implemented by previous versions of this crate and the Python Standard Library.
+        // https://docs.rs/async_zip/0.0.8/src/async_zip/read/mod.rs.html#63-65
+        // https://github.com/python/cpython/blob/820ef62833bd2d84a141adedd9a05998595d6b6d/Lib/zipfile.py#L528
+        let entry_is_dir = entry.filename().ends_with('/');
+
+        let mut entry_reader = reader.entry(index).await.expect("Failed to read ZipEntry");
+
+        if entry_is_dir {
+            // The directory may have been created if iteration is out of order.
+            if !path.exists() {
+                tokio::fs::create_dir_all(&path)
+                    .await
+                    .expect("Failed to create extracted directory");
+            }
+        } else {
+            // Creates parent directories. They may not exist if iteration is out of order
+            // or the archive does not contain directory entries.
+            let parent = path
+                .parent()
+                .expect("A file entry should have parent directories");
+            if !parent.is_dir() {
+                tokio::fs::create_dir_all(parent)
+                    .await
+                    .expect("Failed to create parent directories");
+            }
+            let mut writer = tokio::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&path)
+                .await
+                .expect("Failed to create extracted file");
+            tokio::io::copy(&mut entry_reader, &mut writer)
+                .await
+                .expect("Failed to copy to extracted file");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::process::Command;
+
+    use crate::python_utils::get_executable_path;
+
+    use super::{install_wheel, install_wheel_and_make_available, PACKAGE_BASE_DIR};
+
+    #[tokio::test]
+    async fn test_install_pip() {
+        let out = install_wheel(
+            "https://files.pythonhosted.org/packages/ab/43/508c403c38eeaa5fc86516eb13bb470ce77601b6d2bbcdb16e26328d0a15/pip-23.0-py3-none-any.whl",
+            "b5f88adff801f5ef052bcdef3daa31b55eb67b0fccd6d0106c206fa248e0463c"
+        ).await;
+
+        assert_eq!(
+            out,
+            PACKAGE_BASE_DIR
+                .join("b5f88adff801f5ef052bcdef3daa31b55eb67b0fccd6d0106c206fa248e0463c")
+        );
+    }
+
+    /// Ensure that wheels that we make available in this process are also available in subprocesses
+    #[tokio::test]
+    async fn test_install_pip_subprocess() {
+        install_wheel_and_make_available(
+            "https://files.pythonhosted.org/packages/ab/43/508c403c38eeaa5fc86516eb13bb470ce77601b6d2bbcdb16e26328d0a15/pip-23.0-py3-none-any.whl",
+            "b5f88adff801f5ef052bcdef3daa31b55eb67b0fccd6d0106c206fa248e0463c"
+        ).await;
+
+        let output = Command::new(get_executable_path().unwrap().as_str())
+            .args(["-c", "import sys; print(sys.path)"])
+            .output()
+            .await
+            .unwrap()
+            .stdout;
+
+        let p = String::from_utf8(output).unwrap();
+        assert!(p.contains("b5f88adff801f5ef052bcdef3daa31b55eb67b0fccd6d0106c206fa248e0463c"))
+    }
+}


### PR DESCRIPTION
This PR adds a new `carton-runner-py` crate that contains basic python wheel installation code.

This is the basis for future PRs that will enable packing and loading of python models.