### PR TITLE
Publish `/tmp/carton_logs` as an artifact in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,11 @@ jobs:
           submodules: recursive
       - run: cargo build --verbose
       - run: cargo test --verbose
+      - name: Upload `carton_logs`
+        uses: actions/upload-artifact@v3
+        with:
+          name: tmp_carton_logs
+          path: /tmp/carton_logs
   build_wasm:
     name: WASM Build ${{ matrix.target }}
     runs-on: ubuntu-latest

--- a/source/carton-runner-py/src/pip_utils.rs
+++ b/source/carton-runner-py/src/pip_utils.rs
@@ -58,7 +58,10 @@ pub(crate) async fn get_pip_deps_report(requirements_file_path: PathBuf) -> PipR
     let tempdir = tempfile::tempdir().unwrap();
     let output_file_path = tempdir.path().join("report.json");
 
-    let log_dir = tempfile::tempdir().unwrap();
+    let logs_tmp_dir = std::env::temp_dir().join("carton_logs");
+    tokio::fs::create_dir_all(&logs_tmp_dir).await.unwrap();
+
+    let log_dir = tempfile::tempdir_in(logs_tmp_dir).unwrap();
     log::info!(target: "slowlog", "Finding transitive dependencies using `pip install --report`. This may take a while. See the `pip` logs in {:#?}", log_dir);
 
     // Run pip in a new process to isolate it a little bit from our embedded interpreter


### PR DESCRIPTION
This makes it easier to debug `pip install --report` failures