### PR TITLE
Update `carton-runner-py` to use lunchbox filesystems

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,6 +360,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
+ "lunchbox",
  "ndarray",
  "numpy",
  "path-clean",

--- a/source/carton-runner-py/Cargo.toml
+++ b/source/carton-runner-py/Cargo.toml
@@ -23,3 +23,7 @@ serde_json = "1"
 url = "2.3.1"
 log = "0.4"
 libc = "0.2"
+lunchbox = { version = "0.1", features = ["serde"], default-features = false }
+
+[dev-dependencies]
+lunchbox = { version = "0.1", features = ["serde", "localfs"] }


### PR DESCRIPTION
Update `update_or_generate_lockfile` to replace usage of local paths (`std::path::Path`) with lunchbox paths (`lunchbox::path::Path`) and replace `tokio::fs::*` with the equivalent `lunchbox` methods.