### PR TITLE
Fix a deserialization bug in `anywhere`

### DIFF
--- a/source/anywhere/src/rpc.rs
+++ b/source/anywhere/src/rpc.rs
@@ -38,7 +38,7 @@ use serde::{Deserialize, Serialize};
 use crate::file_ops::ReadableFileOps;
 use crate::file_ops::SeekableFileOps;
 use crate::file_ops::WritableFileOps;
-use crate::serialize::{IoError, SeekFromDef, SerializableMetadata};
+use crate::serialize::{IoError, SeekFromDef, SerializableMetadata, SerializableRelativePathBuf};
 use crate::transport::Transport;
 use crate::types;
 use crate::types::FileHandle;
@@ -355,11 +355,11 @@ autoimpl! {
         // Read only filesystem operations
         #[with_server_context]
         async fn open_file(path: RPCPath) -> std::io::Result<FileHandle>;
-        async fn canonicalize(path: RPCPath) -> std::io::Result<PathBuf>;
+        async fn canonicalize(path: RPCPath) -> std::io::Result<#[serde(with = "SerializableRelativePathBuf")] PathBuf>;
         async fn metadata(path: RPCPath) -> std::io::Result<#[serde(with = "SerializableMetadata")] Metadata>;
         async fn read(path: RPCPath) -> std::io::Result<Vec<u8>>;
         // async fn read_dir(path: RPCPath) -> std::io::Result<ReadDir<Self::ReadDirPollerType, Self>>;
-        async fn read_link(path: RPCPath) -> std::io::Result<PathBuf>;
+        async fn read_link(path: RPCPath) -> std::io::Result<#[serde(with = "SerializableRelativePathBuf")]PathBuf>;
         async fn read_to_string(path: RPCPath) -> std::io::Result<String>;
         async fn symlink_metadata(path: RPCPath) -> std::io::Result<#[serde(with = "SerializableMetadata")] Metadata>;
     }

--- a/source/anywhere/src/serialize.rs
+++ b/source/anywhere/src/serialize.rs
@@ -171,3 +171,22 @@ impl From<SerializableMetadata> for Metadata {
         )
     }
 }
+
+fn path_to_string(path: &lunchbox::path::PathBuf) -> String {
+    path.as_str().to_owned()
+}
+
+// the RelativePath types use `deserialize_any` which doesn't work with bincode
+// An impl for RelativePathBuf
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(remote = "lunchbox::path::PathBuf")]
+pub struct SerializableRelativePathBuf {
+    #[serde(getter = "path_to_string")]
+    inner: String,
+}
+
+impl From<SerializableRelativePathBuf> for lunchbox::path::PathBuf {
+    fn from(value: SerializableRelativePathBuf) -> Self {
+        value.inner.into()
+    }
+}

--- a/source/anywhere/src/transport/serde.rs
+++ b/source/anywhere/src/transport/serde.rs
@@ -134,3 +134,29 @@ impl Transport for SerdeTransport {
         SerdeTransportServer { inner }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{RequestMessageType, ResponseMessageType};
+
+    #[test]
+    fn test_bincode() {
+        // Request
+        let ser = bincode::serialize(&RequestMessageType {
+            rpc_id: 0,
+            msg: crate::rpc::AnywhereRPCRequest::Canonicalize { path: "".into() },
+        })
+        .unwrap();
+
+        let _: RequestMessageType = bincode::deserialize(&ser).unwrap();
+
+        // Response
+        let ser = bincode::serialize(&ResponseMessageType {
+            rpc_id: 0,
+            msg: crate::rpc::AnywhereRPCResponse::Canonicalize { res: "".into() },
+        })
+        .unwrap();
+
+        let _: ResponseMessageType = bincode::deserialize(&ser).unwrap();
+    }
+}

--- a/source/anywhere/src/types.rs
+++ b/source/anywhere/src/types.rs
@@ -13,7 +13,7 @@ use std::{io::Result, pin::Pin, sync::Arc};
 use tokio::io::{AsyncRead, AsyncSeek, AsyncWrite};
 
 // The RPC path on the wire
-pub type RPCPath = lunchbox::path::PathBuf;
+pub type RPCPath = String;
 
 // A handle to a file
 pub type FileHandle = u64;
@@ -329,9 +329,9 @@ trait TypeConversion<T> {
     fn convert(self) -> T;
 }
 
-impl<T: PathType> TypeConversion<lunchbox::path::PathBuf> for T {
-    fn convert(self) -> lunchbox::path::PathBuf {
-        self.as_ref().to_relative_path_buf()
+impl<T: PathType> TypeConversion<String> for T {
+    fn convert(self) -> String {
+        self.as_ref().as_str().to_owned()
     }
 }
 


### PR DESCRIPTION
Lunchbox uses [`relative_path::RelativePathBuf`](https://docs.rs/relative-path/latest/relative_path/struct.RelativePathBuf.html) as its PathBuf type. Unfortunately, the serde deserialization impl for `RelativePathBuf` uses `deserialize_any` which is not compatible with bincode.

This PR fixes the issue by not including `RelativePathBuf` in most RPC methods and by using different serialization/deserialization in the few that remain.