### PR TITLE
Add an end-to-end test of packing a python model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,7 +355,9 @@ name = "carton-runner-py"
 version = "0.0.1"
 dependencies = [
  "async_zip",
+ "carton",
  "carton-runner-interface",
+ "escargot",
  "home",
  "lazy_static",
  "libc",
@@ -367,9 +369,11 @@ dependencies = [
  "pyo3",
  "pyo3-asyncio",
  "reqwest",
+ "semver 1.0.16",
  "serde",
  "serde_json",
  "sha2",
+ "target-lexicon",
  "tempfile",
  "tokio",
  "toml",

--- a/source/carton-runner-interface/src/runner.rs
+++ b/source/carton-runner-interface/src/runner.rs
@@ -183,11 +183,11 @@ impl Runner {
         temp_folder: &lunchbox::path::Path,
     ) -> Result<lunchbox::path::PathBuf, String>
     where
-        T: lunchbox::ReadableFileSystem + MaybeSend + MaybeSync + 'static,
-        T::FileType: lunchbox::types::ReadableFile + MaybeSend + MaybeSync + Unpin,
+        T: lunchbox::WritableFileSystem + MaybeSend + MaybeSync + 'static,
+        T::FileType: lunchbox::types::WritableFile + MaybeSend + MaybeSync + Unpin,
     {
         // Serve the filesystem
-        let token = self.client.serve_readonly_fs(fs.clone()).await;
+        let token = self.client.serve_writable_fs(fs.clone()).await;
 
         match self
             .client

--- a/source/carton-runner-py/Cargo.toml
+++ b/source/carton-runner-py/Cargo.toml
@@ -27,3 +27,7 @@ lunchbox = { version = "0.1", features = ["serde"], default-features = false }
 
 [dev-dependencies]
 lunchbox = { version = "0.1", features = ["serde", "localfs"] }
+carton = { path = "../carton" }
+semver = {version = "1.0.16"}
+target-lexicon = "0.12.5"
+escargot = "0.5.7"

--- a/source/carton-runner-py/src/main.rs
+++ b/source/carton-runner-py/src/main.rs
@@ -1,7 +1,48 @@
+use carton_runner_interface::{
+    server::init_runner,
+    types::{RPCRequestData, RPCResponseData},
+};
+
+use packager::update_or_generate_lockfile;
+
 mod env;
 mod packager;
 mod pip_utils;
 mod python_utils;
 mod wheel;
 
-fn main() {}
+#[tokio::main]
+async fn main() {
+    let mut server = init_runner().await;
+
+    while let Some(req) = server.get_next_request().await {
+        let req_id = req.id;
+        match req.data {
+            RPCRequestData::Load { .. } => {
+                // TODO: implement
+                server
+                    .send_response_for_request(req_id, RPCResponseData::Load)
+                    .await
+                    .unwrap();
+            }
+            RPCRequestData::Pack { fs, input_path, .. } => {
+                let fs = server.get_writable_filesystem(fs).await.unwrap();
+
+                // Update or generate a lockfile in the input dir
+                update_or_generate_lockfile(&fs, &input_path).await;
+
+                // The dir that carton should pack is just the input path
+                server
+                    .send_response_for_request(
+                        req_id,
+                        RPCResponseData::Pack {
+                            output_path: input_path,
+                        },
+                    )
+                    .await
+                    .unwrap();
+            }
+            _ => todo!(),
+        }
+    }
+}

--- a/source/carton-runner-py/tests/pack.rs
+++ b/source/carton-runner-py/tests/pack.rs
@@ -1,0 +1,92 @@
+use carton::{
+    info::RunnerInfo,
+    types::{CartonInfo, GenericStorage, LoadOpts},
+    Carton,
+};
+use semver::VersionReq;
+
+#[tokio::test]
+async fn test_pack_python_model() {
+    // Make sure the py runner is built
+    let runner_path = escargot::CargoBuild::new()
+        .package("carton-runner-py")
+        .run()
+        .unwrap()
+        .path()
+        .display()
+        .to_string();
+    println!("Runner Path: {}", runner_path);
+
+    println!("Creating runner.toml");
+    let runner_toml = format!(
+        r#"
+# This is a runner.toml that runs against the release runner
+version = 1
+
+[[runner]]
+runner_name = "python"
+framework_version = "1.0.0"
+runner_compat_version = 1
+runner_interface_version = 1
+runner_release_date = "1979-05-27T07:32:00Z"
+
+# A path to the runner binary. This can be absolute or relative to this file
+runner_path = "{runner_path}"
+
+# A target triple
+platform = "{}"
+"#,
+        target_lexicon::HOST.to_string()
+    );
+
+    let tempdir = tempfile::tempdir().unwrap();
+    std::fs::write(tempdir.path().join("runner.toml"), runner_toml).unwrap();
+
+    // TODO don't do this
+    std::env::set_var("CARTON_RUNNER_DIR", tempdir.path().as_os_str());
+
+    let pack_opts: CartonInfo<GenericStorage> = CartonInfo {
+        model_name: None,
+        short_description: None,
+        model_description: None,
+        required_platforms: None,
+        inputs: None,
+        outputs: None,
+        self_tests: None,
+        examples: None,
+        runner: RunnerInfo {
+            runner_name: "python".into(),
+            required_framework_version: VersionReq::parse("*").unwrap(),
+            runner_compat_version: None,
+            opts: None,
+        },
+        misc_files: None,
+    };
+
+    // Create a "model" with a dependency
+    let model_dir = tempfile::tempdir().unwrap();
+    tokio::fs::write(model_dir.path().join("requirements.txt"), "xgboost==1.7.3")
+        .await
+        .unwrap();
+
+    // TODO: use `pack` instead of `load_unpacked` once `carton::format::v1::save` is implemented
+    let _model = Carton::load_unpacked(
+        model_dir.path().to_str().unwrap().to_owned(),
+        pack_opts,
+        LoadOpts::default(),
+    )
+    .await
+    .unwrap();
+
+    // Load the generated lockfile
+    let lockfile = String::from_utf8(
+        tokio::fs::read(&model_dir.path().join(".carton/carton.lock"))
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+
+    assert!(lockfile.contains("xgboost"));
+    assert!(lockfile.contains("scipy"));
+    assert!(lockfile.contains("numpy"));
+}


### PR DESCRIPTION
This PR adds an end-to-end test of packing a python model. It also changes `pack` in the runner to serve a writable filesystem instead of a read-only one.