### PR TITLE
Implement `slowlog` to let the user know when an operation takes a while

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -328,6 +328,7 @@ dependencies = [
  "dashmap",
  "js-sys",
  "libc",
+ "log",
  "lunchbox",
  "ndarray",
  "once_cell",

--- a/source/carton-runner-interface/Cargo.toml
+++ b/source/carton-runner-interface/Cargo.toml
@@ -16,6 +16,7 @@ lunchbox = { version = "0.1", features = ["serde"], default-features = false }
 semver = {version = "1.0.16", features = ["serde"]}
 once_cell = "1.17.0"
 serde_bytes = "0.11"
+log = "0.4"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 # This version is pinned because we don't want to accidentally break our transport

--- a/source/carton-runner-interface/src/lib.rs
+++ b/source/carton-runner-interface/src/lib.rs
@@ -25,6 +25,7 @@ pub mod runner;
 
 if_not_wasm! {
     pub mod server;
+    pub mod slowlog;
 }
 
 if_not_wasm! {

--- a/source/carton-runner-interface/src/slowlog.rs
+++ b/source/carton-runner-interface/src/slowlog.rs
@@ -1,0 +1,43 @@
+//! Utility function to log if a task is taking a long time
+
+use std::time::{Duration, Instant};
+
+use tokio::sync::oneshot;
+
+pub struct SlowLog {
+    done: Option<oneshot::Sender<()>>,
+}
+
+impl SlowLog {
+    pub fn done(&mut self) {
+        self.done.take().map(|d| d.send(()).unwrap());
+    }
+}
+
+impl Drop for SlowLog {
+    fn drop(&mut self) {
+        self.done();
+    }
+}
+
+pub async fn slowlog<S>(msg: S, interval_seconds: u64) -> SlowLog
+where
+    S: Into<String>,
+{
+    let msg = msg.into();
+    let (tx, mut rx) = oneshot::channel::<()>();
+    tokio::spawn(async move {
+        let start = Instant::now();
+        loop {
+            match tokio::time::timeout(Duration::from_secs(interval_seconds), &mut rx).await {
+                Ok(_) => break,
+                Err(_) => {
+                    let duration = start.elapsed().as_secs();
+                    log::info!(target: "slowlog", "Task running for {duration} seconds: {msg}")
+                }
+            }
+        }
+    });
+
+    SlowLog { done: Some(tx) }
+}


### PR DESCRIPTION
This PR implements a `slowlog` function that periodically logs during long-running tasks.

In the future, we can expose this to users so it's clear why something is taking a long time (if we anticipate it potentially taking a while)