### PR TITLE
Add progress updates to `slowlog`

### DIFF
--- a/source/carton-runner-interface/src/slowlog.rs
+++ b/source/carton-runner-interface/src/slowlog.rs
@@ -1,30 +1,80 @@
 //! Utility function to log if a task is taking a long time
 
-use std::time::{Duration, Instant};
+use std::{
+    fmt::Display,
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
+};
 
 use tokio::sync::oneshot;
 
-pub struct SlowLog {
-    done: Option<oneshot::Sender<()>>,
+pub struct Progress<T> {
+    progress: Option<T>,
+    total: Option<T>,
 }
 
-impl SlowLog {
-    pub fn done(&mut self) {
-        self.done.take().map(|d| d.send(()).unwrap());
+impl<T> Default for Progress<T> {
+    fn default() -> Self {
+        Self {
+            progress: Default::default(),
+            total: Default::default(),
+        }
     }
 }
 
-impl Drop for SlowLog {
+pub struct SlowLog<T> {
+    done: Option<oneshot::Sender<()>>,
+
+    // This is okay because it's likely not going to have any significant contention
+    progress: Arc<Mutex<Progress<T>>>,
+}
+
+impl<T> SlowLog<T> {
+    pub fn done(&mut self) {
+        self.done.take().map(|d| d.send(()).unwrap());
+    }
+
+    pub fn set_total(&self, total: Option<T>) {
+        self.progress.lock().unwrap().total = total;
+    }
+
+    pub fn set_progress(&self, progress: Option<T>) {
+        self.progress.lock().unwrap().progress = progress;
+    }
+}
+
+pub struct WithoutProgress;
+impl Display for WithoutProgress {
+    fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Ok(())
+    }
+}
+
+impl SlowLog<WithoutProgress> {
+    /// Just a hint to the compiler so it can figure out the type of T if we
+    /// never call `set_progress` or `set_total`
+    pub fn without_progress(self) -> Self {
+        self
+    }
+}
+
+impl<T> Drop for SlowLog<T> {
     fn drop(&mut self) {
         self.done();
     }
 }
 
-pub async fn slowlog<S>(msg: S, interval_seconds: u64) -> SlowLog
+pub async fn slowlog<S, T>(msg: S, interval_seconds: u64) -> SlowLog<T>
 where
     S: Into<String>,
+    T: Send + 'static + Display,
 {
     let msg = msg.into();
+
+    // Holds progress information
+    let progress = Arc::new(Mutex::new(Progress::default()));
+
+    let progress2 = progress.clone();
     let (tx, mut rx) = oneshot::channel::<()>();
     tokio::spawn(async move {
         let start = Instant::now();
@@ -32,12 +82,27 @@ where
             match tokio::time::timeout(Duration::from_secs(interval_seconds), &mut rx).await {
                 Ok(_) => break,
                 Err(_) => {
+                    // Check if we have progress info
+                    let p = {
+                        let guard = progress2.lock().unwrap();
+                        match (&guard.progress, &guard.total) {
+                            (None, None) => "".to_string(),
+                            (None, Some(total)) => format!(" ({total})"),
+                            (Some(progress), None) => format!(" ({progress} / unknown)"),
+                            (Some(progress), Some(total)) => format!(" ({progress} / {total})"),
+                        }
+                    };
+
+                    // Get the duration since we started and log
                     let duration = start.elapsed().as_secs();
-                    log::info!(target: "slowlog", "Task running for {duration} seconds: {msg}")
+                    log::info!(target: "slowlog", "Task running for {duration} seconds: {msg}{p}")
                 }
             }
         }
     });
 
-    SlowLog { done: Some(tx) }
+    SlowLog {
+        done: Some(tx),
+        progress,
+    }
 }

--- a/source/carton-runner-py/src/packager.rs
+++ b/source/carton-runner-py/src/packager.rs
@@ -168,7 +168,9 @@ where
 
         log::info!(target: "slowlog", "Fetching and bundling non-pypi wheel: {:#?}", parsed);
 
-        let mut sl = slowlog(format!("Downloading file '{}'", &item.download_info.url), 5).await;
+        let mut sl = slowlog(format!("Downloading file '{}'", &item.download_info.url), 5)
+            .await
+            .without_progress();
 
         let relative_path = format!(".carton/bundled_wheels/{sha256}/{fname}");
         let bundled_path = code_dir.join(&relative_path);
@@ -215,7 +217,7 @@ where
         let log_dir = tempfile::tempdir_in(logs_tmp_dir).unwrap();
         log::info!(target: "slowlog", "Building wheels for non-wheel dependencies using `pip wheel`. This may take a while. See the `pip` logs in {:#?}", log_dir);
 
-        let mut sl = slowlog("`pip wheel`", 5).await;
+        let mut sl = slowlog("`pip wheel`", 5).await.without_progress();
 
         // Run pip in a new process to isolate it a little bit from our embedded interpreter
         let build_success = Command::new(get_executable_path().unwrap().as_str())

--- a/source/carton-runner-py/src/pip_utils.rs
+++ b/source/carton-runner-py/src/pip_utils.rs
@@ -68,7 +68,9 @@ where
     let log_dir = tempfile::tempdir_in(logs_tmp_dir).unwrap();
     log::info!(target: "slowlog", "Finding transitive dependencies using `pip install --report`. This may take a while. See the `pip` logs in {:#?}", log_dir.path());
 
-    let mut sl = slowlog("`pip install --report`", 5).await;
+    let mut sl = slowlog("`pip install --report`", 5)
+        .await
+        .without_progress();
 
     // Run pip in a new process to isolate it a little bit from our embedded interpreter
     let success = Command::new(get_executable_path().unwrap().as_str())


### PR DESCRIPTION
`slowlog` logs can now show progress.

Ex:
```
Task running for 15 seconds: Downloading file 'https://...' (160.4 MB / 193.6 MB)
```