### PR TITLE
Move zip extraction into a new `carton-utils` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,6 +375,7 @@ dependencies = [
  "bytesize",
  "carton",
  "carton-runner-interface",
+ "carton-utils",
  "escargot",
  "findshlibs",
  "home",
@@ -400,6 +401,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "carton-utils"
+version = "0.0.1"
+dependencies = [
+ "async_zip",
+ "flate2",
+ "infer",
+ "libc",
+ "log",
+ "path-clean",
+ "tar",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,6 +428,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
 dependencies = [
  "jobserver",
+]
+
+[[package]]
+name = "cfb"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38f2da7a0a2c4ccf0065be06397cc26a81f4e528be095826eee9d4adbb8c60f"
+dependencies = [
+ "byteorder",
+ "fnv",
+ "uuid",
 ]
 
 [[package]]
@@ -865,6 +892,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e884668cd0c7480504233e951174ddc3b382f7c2666e3b7310b5c4e7b0c37f9"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "findshlibs"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1253,6 +1292,15 @@ name = "indoc"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adab1eaa3408fb7f0c777a73e7465fd5656136fc93b670eb6df3c88c2c1344e3"
+
+[[package]]
+name = "infer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a898e4b7951673fce96614ce5751d13c40fc5674bc2d759288e46c3ab62598b3"
+dependencies = [
+ "cfb",
+]
 
 [[package]]
 name = "instant"
@@ -2406,6 +2454,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
 
 [[package]]
+name = "tar"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2790,6 +2849,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
+
+[[package]]
 name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3079,6 +3144,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "xattr"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "source/carton",
+    "source/carton-utils",
     "source/carton-runner-interface",
     "source/carton-bindings-py",
     "source/carton-bindings-nodejs",

--- a/source/carton-runner-py/Cargo.toml
+++ b/source/carton-runner-py/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 carton-runner-interface = { path = "../carton-runner-interface" }
+carton-utils = { path = "../carton-utils" }
 tokio = { version = "1", features = ["full"] }
 pyo3 = { version = "0.17.3"}
 pyo3-asyncio = { version = "0.17", features = ["attributes", "tokio-runtime"] }

--- a/source/carton-runner-py/src/loader.rs
+++ b/source/carton-runner-py/src/loader.rs
@@ -1,15 +1,13 @@
 use std::collections::{HashMap, VecDeque};
 
 use carton_runner_interface::types::RunnerOpt;
+use carton_utils::archive::extract_zip;
 use lunchbox::path::{LunchboxPathUtils, PathBuf};
 use pyo3::prelude::*;
 
 use crate::{
-    env::EnvironmentMarkers,
-    model::Model,
-    packager::CartonLock,
-    python_utils::add_to_sys_path,
-    wheel::{install_wheel_and_make_available, unzip_file},
+    env::EnvironmentMarkers, model::Model, packager::CartonLock, python_utils::add_to_sys_path,
+    wheel::install_wheel_and_make_available,
 };
 
 pub(crate) async fn load<F>(
@@ -85,7 +83,7 @@ where
                         tokio::io::copy(&mut f, &mut target).await.unwrap();
 
                         // Unzip to our temp packages dir for this model
-                        unzip_file(&local_path, &temp_packages_dir).await;
+                        extract_zip(&local_path, &temp_packages_dir).await;
                     }));
                 } else {
                     return Err(format!("The .carton/carton.lock file references a file ({bundled_whl_path}) that does not exist. It is possible that the lockfile was added to version control but the referenced files were not. Please repackage the model and try again. TODO: link"));

--- a/source/carton-runner-py/src/wheel.rs
+++ b/source/carton-runner-py/src/wheel.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 
 use async_zip::read::fs::ZipFileReader;
 use carton_runner_interface::slowlog::{slowlog, Progress};
+use carton_utils::archive::{extract_zip, with_atomic_extraction};
 use lazy_static::lazy_static;
 use path_clean::PathClean;
 use sha2::{Digest, Sha256};
@@ -33,7 +34,7 @@ pub async fn install_wheel(url: &str, sha256: &str) -> PathBuf {
     let target_dir = PACKAGE_BASE_DIR.join(sha256);
     if target_dir.exists() {
         // This already exists
-        // TODO: we should probably do some locking to avoid wasted parallel installations
+        // TODO: we should probably also do some locking to avoid wasted parallel installations
         return target_dir;
     }
 
@@ -79,90 +80,12 @@ pub async fn install_wheel(url: &str, sha256: &str) -> PathBuf {
         .without_progress();
 
     // Unzip
-    let extraction_dir = tempdir.path().join("extraction");
-    unzip_file(&download_path, &extraction_dir).await;
+    with_atomic_extraction(&download_path, &target_dir, extract_zip).await;
 
     sl.done();
 
-    // Move to the target directory. This should be atomic so it won't break anything
-    // if multiple installs happen at the same time.
-    match tokio::fs::rename(extraction_dir, &target_dir).await {
-        Err(e) if e.raw_os_error() == Some(libc::ENOTEMPTY) => {
-            // This can happen if another installation created the target directory before we called
-            // rename.
-            // We don't need to do anything here
-        }
-        e => e.unwrap(),
-    }
-
     // Return the path to add to sys.path
     target_dir
-}
-
-// Based on https://github.com/Majored/rs-async-zip/blob/main/examples/file_extraction.rs
-/// Extracts everything from the ZIP archive to the output directory
-pub(crate) async fn unzip_file(archive: &Path, out_dir: &Path) {
-    let mut handles = Vec::new();
-    let reader = ZipFileReader::new(archive)
-        .await
-        .expect("Failed to read zip file");
-    for index in 0..reader.file().entries().len() {
-        let entry = &reader.file().entries().get(index).unwrap().entry();
-
-        // Normalize the file path
-        let path = out_dir.join(entry.filename()).clean();
-
-        // Ensure that path is within the base dir
-        if !path.starts_with(out_dir) {
-            panic!("Error: extracted file path does not start with the output dir")
-        }
-
-        // If the filename of the entry ends with '/', it is treated as a directory.
-        // This is implemented by previous versions of this crate and the Python Standard Library.
-        // https://docs.rs/async_zip/0.0.8/src/async_zip/read/mod.rs.html#63-65
-        // https://github.com/python/cpython/blob/820ef62833bd2d84a141adedd9a05998595d6b6d/Lib/zipfile.py#L528
-        let entry_is_dir = entry.filename().ends_with('/');
-
-        if entry_is_dir {
-            // The directory may have been created if iteration is out of order.
-            if !path.exists() {
-                tokio::fs::create_dir_all(&path)
-                    .await
-                    .expect("Failed to create extracted directory");
-            }
-        } else {
-            // Creates parent directories. They may not exist if iteration is out of order
-            // or the archive does not contain directory entries.
-            let parent = path
-                .parent()
-                .expect("A file entry should have parent directories");
-            if !parent.is_dir() {
-                tokio::fs::create_dir_all(parent)
-                    .await
-                    .expect("Failed to create parent directories");
-            }
-            let mut writer = tokio::fs::OpenOptions::new()
-                .write(true)
-                .create_new(true)
-                .open(&path)
-                .await
-                .expect("Failed to create extracted file");
-
-            // Spawn a task to extract
-            let reader = reader.clone();
-            handles.push(tokio::spawn(async move {
-                let mut entry_reader = reader.entry(index).await.expect("Failed to read ZipEntry");
-                tokio::io::copy(&mut entry_reader, &mut writer)
-                    .await
-                    .expect("Failed to copy to extracted file");
-            }));
-        }
-    }
-
-    // Wait until all the files are extracted
-    for handle in handles {
-        handle.await.unwrap();
-    }
 }
 
 #[cfg(test)]

--- a/source/carton-utils/Cargo.toml
+++ b/source/carton-utils/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "carton-utils"
+version = "0.0.1"
+edition = "2021"
+
+[dependencies]
+tokio = { version = "1", features = [] }
+log = "0.4"
+tempfile = "3.3.0"
+async_zip = {version = "0.0.11", features = ["full"]}
+infer = "0.12.0"
+path-clean = "0.1.0"
+flate2 = "1.0"
+tar = "0.4"
+libc = "0.2"

--- a/source/carton-utils/src/archive.rs
+++ b/source/carton-utils/src/archive.rs
@@ -1,0 +1,164 @@
+use flate2::read::GzDecoder;
+use path_clean::PathClean;
+use std::{
+    future::Future,
+    io::Read,
+    path::{Path, PathBuf},
+};
+
+use async_zip::read::fs::ZipFileReader;
+
+// Based on https://github.com/Majored/rs-async-zip/blob/main/examples/file_extraction.rs
+/// Extracts a ZIP archive to the output directory
+pub async fn extract_zip<P: AsRef<Path>>(archive: P, out_dir: P) {
+    let out_dir = out_dir.as_ref();
+    let mut handles = Vec::new();
+    let reader = ZipFileReader::new(archive)
+        .await
+        .expect("Failed to read zip file");
+    for index in 0..reader.file().entries().len() {
+        let entry = &reader.file().entries().get(index).unwrap().entry();
+
+        // Normalize the file path
+        let path = out_dir.join(entry.filename()).clean();
+
+        // Ensure that path is within the base dir
+        if !path.starts_with(out_dir) {
+            panic!("Error: extracted file path does not start with the output dir")
+        }
+
+        // If the filename of the entry ends with '/', it is treated as a directory.
+        // This is implemented by the Python Standard Library.
+        // https://github.com/python/cpython/blob/820ef62833bd2d84a141adedd9a05998595d6b6d/Lib/zipfile.py#L528
+        let entry_is_dir = entry.filename().ends_with('/');
+
+        if entry_is_dir {
+            // The directory may have been created if iteration is out of order.
+            if !path.exists() {
+                tokio::fs::create_dir_all(&path)
+                    .await
+                    .expect("Failed to create extracted directory");
+            }
+        } else {
+            // Creates parent directories. They may not exist if iteration is out of order
+            // or the archive does not contain directory entries.
+            let parent = path
+                .parent()
+                .expect("A file entry should have parent directories");
+            if !parent.is_dir() {
+                tokio::fs::create_dir_all(parent)
+                    .await
+                    .expect("Failed to create parent directories");
+            }
+            let mut writer = tokio::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&path)
+                .await
+                .expect("Failed to create extracted file");
+
+            // Spawn a task to extract
+            let reader = reader.clone();
+            handles.push(tokio::spawn(async move {
+                let mut entry_reader = reader.entry(index).await.expect("Failed to read ZipEntry");
+                tokio::io::copy(&mut entry_reader, &mut writer)
+                    .await
+                    .expect("Failed to copy to extracted file");
+            }));
+        }
+    }
+
+    // Wait until all the files are extracted
+    for handle in handles {
+        handle.await.unwrap();
+    }
+}
+
+/// Extracts a tar.gz archive to the output directory
+pub async fn extract_tar_gz<P: Into<PathBuf>>(archive: P, out_dir: P) {
+    let archive = archive.into();
+    let out_dir = out_dir.into();
+    tokio::task::spawn_blocking(move || {
+        let gz = std::fs::File::open(archive).unwrap();
+        let tar = GzDecoder::new(gz);
+        let mut archive = tar::Archive::new(tar);
+        archive.unpack(&out_dir).unwrap();
+    })
+    .await
+    .unwrap();
+}
+
+/// Extracts a tar archive to the output directory
+pub async fn extract_tar<P: Into<PathBuf>>(archive: P, out_dir: P) {
+    let archive = archive.into();
+    let out_dir = out_dir.into();
+    tokio::task::spawn_blocking(move || {
+        let tar = std::fs::File::open(archive).unwrap();
+        let mut archive = tar::Archive::new(tar);
+        archive.unpack(&out_dir).unwrap();
+    })
+    .await
+    .unwrap();
+}
+
+/// Extract an archive (either zip, tar, or tar.gz)
+pub async fn extract(archive: &Path, out_dir: &Path) {
+    // TODO: don't use `expect` and return an error
+    let kind = infer::get_from_path(archive)
+        .expect("file is read successfully")
+        .expect("file type is known");
+
+    match kind.mime_type() {
+        "application/zip" => extract_zip(archive, out_dir).await,
+        "application/gzip" => {
+            let gz = std::fs::File::open(archive).unwrap();
+            let decoder = GzDecoder::new(gz);
+
+            // We only need the first 261 bytes to tell if it's a tar file
+            let mut buf = Vec::with_capacity(512);
+            decoder.take(512).read_to_end(&mut buf).unwrap();
+            if infer::archive::is_tar(&buf) {
+                extract_tar_gz(&archive, &out_dir).await;
+            } else {
+                panic!("Got a gz file but it wasn't a tar.gz");
+            }
+        }
+        "application/x-tar" => {
+            extract_tar(&archive, &out_dir).await;
+        }
+        other => panic!("Got an unsupported archive type: {other}"),
+    }
+}
+
+/// This calls the provided function `do_extract` with a temporary path to extract into and then moves that dir to `target_dir`
+/// This should be atomic so it won't cause broken output if multiple extractions happen at the same time.
+/// Note: if `target_dir` exists, this function doesn't do anything
+pub async fn with_atomic_extraction<F, Fut>(archive: &Path, target_dir: &Path, do_extract: F)
+where
+    F: FnOnce(PathBuf, PathBuf) -> Fut,
+    Fut: Future<Output = ()>,
+{
+    if target_dir.exists() {
+        // This already exists
+        // TODO: we should probably also do some locking to avoid wasted parallel extractions
+        return;
+    }
+
+    // Create a temp dir
+    let tempdir = tempfile::tempdir().unwrap();
+    let extraction_dir = tempdir.path().join("extraction");
+
+    // Extract
+    do_extract(archive.to_owned(), extraction_dir.clone()).await;
+
+    // Move to the target directory. This should be atomic so it won't break anything
+    // if multiple installs happen at the same time.
+    match tokio::fs::rename(&extraction_dir, &target_dir).await {
+        Err(e) if e.raw_os_error() == Some(libc::ENOTEMPTY) => {
+            // This can happen if another installation created the target directory before we called
+            // rename.
+            // We don't need to do anything here
+        }
+        e => e.unwrap(),
+    }
+}

--- a/source/carton-utils/src/lib.rs
+++ b/source/carton-utils/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod archive;


### PR DESCRIPTION
This PR moves zip extraction logic from `carton-runner-py` to a new `carton-utils` crate.

It also introduces small `extract`, `extract_tar`, and `extract_tar_gz` functions