### PR TITLE
Move file downloading to `carton-utils`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,11 +407,15 @@ dependencies = [
  "async_zip",
  "flate2",
  "infer",
+ "lazy_static",
  "libc",
  "log",
  "path-clean",
+ "reqwest",
+ "sha2",
  "tar",
  "tempfile",
+ "thiserror",
  "tokio",
 ]
 

--- a/source/carton-utils/Cargo.toml
+++ b/source/carton-utils/Cargo.toml
@@ -13,3 +13,7 @@ path-clean = "0.1.0"
 flate2 = "1.0"
 tar = "0.4"
 libc = "0.2"
+lazy_static = "1.4.0"
+reqwest = { version = "0.11" }
+sha2 = "0.10.6"
+thiserror = "1"

--- a/source/carton-utils/src/download.rs
+++ b/source/carton-utils/src/download.rs
@@ -1,0 +1,49 @@
+use lazy_static::lazy_static;
+use sha2::{Digest, Sha256};
+use std::{future::Future, path::Path};
+
+use crate::error::{DownloadError, Result};
+
+lazy_static! {
+    static ref CLIENT: reqwest::Client = reqwest::Client::new();
+}
+
+/// Download a file with progress updates
+pub async fn uncached_download(
+    url: &str,
+    sha256: &str,
+    download_path: &Path,
+    mut on_content_len: impl FnMut(/* total */ Option<u64>),
+    mut progress_update: impl FnMut(/* downloaded */ u64),
+) -> Result<()> {
+    // Create the file
+    let mut outfile = tokio::fs::File::create(&download_path).await.unwrap();
+
+    // Download and copy to the target file while computing the sha256
+    let mut hasher = Sha256::new();
+    let mut res = CLIENT.get(url).send().await.unwrap();
+
+    on_content_len(res.content_length());
+    let mut downloaded = 0;
+
+    while let Some(chunk) = res.chunk().await.unwrap() {
+        // TODO: see if we should offload this to a blocking thread
+        hasher.update(&chunk);
+        tokio::io::copy(&mut chunk.as_ref(), &mut outfile)
+            .await
+            .unwrap();
+        downloaded += chunk.len() as u64;
+        progress_update(downloaded);
+    }
+
+    // Make sure the sha256 matches the expected value
+    let actual_sha256 = format!("{:x}", hasher.finalize());
+    if sha256 != actual_sha256 {
+        return Err(DownloadError::Sha256Mismatch {
+            actual: actual_sha256,
+            expected: sha256.into(),
+        });
+    }
+
+    Ok(())
+}

--- a/source/carton-utils/src/error.rs
+++ b/source/carton-utils/src/error.rs
@@ -1,0 +1,16 @@
+use thiserror::Error;
+
+pub type Result<T> = std::result::Result<T, DownloadError>;
+
+#[non_exhaustive]
+#[derive(Debug, Error)]
+pub enum DownloadError {
+    #[error("{0}")]
+    FetchError(#[from] reqwest::Error),
+
+    #[error("Sha256 Mismatch. Expected {expected}, but got {actual}")]
+    Sha256Mismatch { actual: String, expected: String },
+
+    #[error("Error: {0}")]
+    Other(&'static str),
+}

--- a/source/carton-utils/src/lib.rs
+++ b/source/carton-utils/src/lib.rs
@@ -1,1 +1,3 @@
 pub mod archive;
+pub mod download;
+pub mod error;


### PR DESCRIPTION
This PR moves file downloading logic from `carton-runner-py` to `carton-utils`.