### PR TITLE
Initial implementation of runner packaging

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,7 +6,3 @@ rustflags = ["--cfg", "tokio_unstable"]
 # Set a default target so that build caches are saved correctly when switching targets
 # https://doc.rust-lang.org/cargo/guide/build-cache.html
 target = ["x86_64-unknown-linux-gnu"]
-
-[env]
-# We'll default to python 3.10
-PYO3_CONFIG_FILE = { value = "build/python_configs/cpython3.10.9", relative = true }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,11 +277,11 @@ dependencies = [
  "bytes",
  "carton-macros",
  "carton-runner-interface",
+ "carton-runner-packager",
  "chrono",
  "console-subscriber",
  "criterion",
  "escargot",
- "futures",
  "lazy_static",
  "lunchbox",
  "ndarray",
@@ -296,7 +296,6 @@ dependencies = [
  "tokio",
  "toml",
  "url",
- "walkdir",
  "zipfs",
 ]
 
@@ -368,6 +367,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "carton-runner-packager"
+version = "0.0.1"
+dependencies = [
+ "async_zip",
+ "carton-utils",
+ "chrono",
+ "escargot",
+ "futures",
+ "log",
+ "reqwest",
+ "semver 1.0.16",
+ "serde",
+ "serde_json",
+ "sha2",
+ "target-lexicon",
+ "tempfile",
+ "thiserror",
+ "tokio",
+ "toml",
+ "url",
+ "walkdir",
+]
+
+[[package]]
 name = "carton-runner-py"
 version = "0.0.1"
 dependencies = [
@@ -375,6 +398,7 @@ dependencies = [
  "bytesize",
  "carton",
  "carton-runner-interface",
+ "carton-runner-packager",
  "carton-utils",
  "escargot",
  "findshlibs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "source/carton",
     "source/carton-utils",
+    "source/carton-runner-packager",
     "source/carton-runner-interface",
     "source/carton-bindings-py",
     "source/carton-bindings-nodejs",

--- a/docs/specification/runner.md
+++ b/docs/specification/runner.md
@@ -71,7 +71,7 @@ The carton library fetches a list of official runners from a well known URL (TOD
 [
     {
         "runner_name": "",
-        "manifest_sha256": "", // The sha256 of the MANIFEST file
+        "id": "", // A hash combining each of the sha256s in download_info. This is an implementation detail that could change
         "framework_version": "",
         "runner_compat_version": 1,
         "runner_interface_version": 1,
@@ -79,8 +79,7 @@ The carton library fetches a list of official runners from a well known URL (TOD
 
         // A list of URLs to zip, tar, or tar.gz files
         // The files are downloaded and unpacked based on `relative_path` below
-        // The resulting folder structure MUST have a runner.toml and a MANIFEST in the root directory
-        // The MANIFEST is in the same format as in the carton file format.
+        // The resulting folder structure MUST have a runner.toml in the root directory
         // Being able to split downloads into multiple files allows us to keep releases small and makes it more
         // feasible to have a regular release schedule.
         "download_info": [

--- a/source/carton-bindings-py/Cargo.toml
+++ b/source/carton-bindings-py/Cargo.toml
@@ -3,10 +3,6 @@ name = "carton-bindings-py"
 version = "0.1.0"
 edition = "2021"
 
-# Sets LD_LIBRARY_PATH so we can find libpython at runtime during tests
-# TODO: move it to a more shared location
-build = "../carton-runner-py/build.rs"
-
 [lib]
 name = "carton"
 crate-type = ["cdylib"]

--- a/source/carton-runner-packager/Cargo.toml
+++ b/source/carton-runner-packager/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "carton-runner-packager"
+version = "0.0.1"
+edition = "2021"
+
+[dependencies]
+carton-utils = { path = "../carton-utils" }
+tokio = { version = "1", features = ["full"] }
+toml = "0.5"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1"
+url = "2.3.1"
+log = "0.4"
+escargot = "0.5.7"
+semver = {version = "1.0.16"}
+target-lexicon = "0.12.5"
+chrono = {version = "0.4.23", features = ["serde"]}
+tempfile = "3.3.0"
+reqwest = { version = "0.11", features = ["json"] }
+async_zip = {version = "0.0.11", features = ["full"]}
+sha2 = "0.10.6"
+walkdir = "2.3.2"
+futures = "0.3"
+thiserror = "1"

--- a/source/carton-runner-packager/src/lib.rs
+++ b/source/carton-runner-packager/src/lib.rs
@@ -1,0 +1,196 @@
+use std::{
+    future::Future,
+    path::{Path, PathBuf},
+};
+
+use async_zip::{write::ZipFileWriter, ZipEntryBuilder};
+use carton_utils::{
+    archive::{extract, with_atomic_extraction},
+    download::uncached_download,
+};
+use chrono::{DateTime, Utc};
+use discovery::{get_runner_dir, Config, RunnerInfo};
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use url::{ParseError, Url};
+
+pub mod discovery;
+
+/// Package a runner along with additional list zip or tar files to download and unpack at installation time
+/// `upload_runner` is a function that is given the data for a `runner.zip` file along with its sha256 and returns a url
+pub async fn package<F, Fut>(
+    mut info: RunnerInfo,
+    mut additional: Vec<DownloadItem>,
+    upload_runner: F,
+) -> DownloadInfo
+where
+    F: FnOnce(Vec<u8>, String) -> Fut,
+    Fut: Future<Output = String>,
+{
+    // Create a zip file in memory
+    let mut zip = Vec::new();
+    let mut writer = ZipFileWriter::new(&mut zip);
+
+    // Add the runner
+    writer
+        .write_entry_whole(
+            ZipEntryBuilder::new("runner".to_string(), async_zip::Compression::Zstd)
+                .attribute_compatibility(async_zip::AttributeCompatibility::Unix)
+                .unix_permissions(0o755), // Everyone gets read + execute
+            &tokio::fs::read(info.runner_path).await.unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Modify the runner path and create a runner.toml file
+    info.runner_path = "./runner".into();
+    let runner_toml = toml::to_string_pretty(&Config {
+        version: 1,
+        runner: vec![info.clone()],
+    })
+    .unwrap();
+
+    // Add it to the zip
+    writer
+        .write_entry_whole(
+            ZipEntryBuilder::new("runner.toml".to_string(), async_zip::Compression::Zstd)
+                .attribute_compatibility(async_zip::AttributeCompatibility::Unix)
+                .unix_permissions(0o644), // Everyone gets read,
+            runner_toml.as_bytes(),
+        )
+        .await
+        .unwrap();
+
+    // Close the writer
+    writer.close().await.unwrap();
+
+    // Compute the sha256 of the zip file
+    let mut hasher = Sha256::new();
+    hasher.update(&zip);
+    let zip_sha256 = format!("{:x}", hasher.finalize());
+
+    // Upload the runner and get the url
+    // TODO: cloning the sha256 makes lifetimes for the closure simpler. Figure out if there's a way to do this more cleanly
+    let url = upload_runner(zip, zip_sha256.clone()).await;
+
+    // Insert the runner zip file at the beginning
+    additional.insert(
+        0,
+        DownloadItem {
+            url,
+            sha256: zip_sha256,
+            relative_path: "".into(),
+        },
+    );
+
+    // Compute the sha256 of the sha256s of all the items in `additional`
+    // to generate a unique id for this runner package
+    let mut hasher = Sha256::new();
+    for item in &additional {
+        hasher.update(&item.sha256);
+    }
+
+    let id = format!("{:x}", hasher.finalize());
+
+    // Create the download config
+    DownloadInfo {
+        runner_name: info.runner_name,
+        id,
+        framework_version: info.framework_version,
+        runner_compat_version: info.runner_compat_version,
+        runner_interface_version: info.runner_interface_version,
+        runner_release_date: info.runner_release_date,
+        download_info: additional,
+        platform: info.platform,
+    }
+}
+
+// TODO: add slowlog for long running downloads
+/// Install the runner if it doesn't already exist
+pub async fn install(info: DownloadInfo, allow_local_files: bool) {
+    let runner_base_dir = PathBuf::from(get_runner_dir());
+
+    // TODO: validate that this joined path is safe
+    let runner_dir = runner_base_dir.join(&info.id);
+
+    // Extract into a temp dir and then move to the actual location
+    with_atomic_extraction(&runner_dir, |runner_dir| async move {
+        let mut handles = Vec::new();
+        for file in info.download_info {
+            // If url is a local file, make sure allow_local_files is true
+            if is_file_path(&file.url) && !allow_local_files {
+                panic!(
+                    "Tried to install runner from local file '{}', but `allow_local_files` was not set",
+                    &file.url
+                );
+            }
+
+            // TODO: validate that this joined path is safe
+            let target_dir = runner_dir.join(&file.relative_path);
+
+            // Spawn tasks to download and extract
+            handles.push(tokio::spawn(async move {
+                let tempdir = tempfile::tempdir().unwrap();
+                let download_path = tempdir.path().join("download");
+
+                // Check if we actually need to download anything
+                let download_path = if is_file_path(&file.url) {
+                    Path::new(&file.url)
+                } else {
+                    // Uncached download because there's probably not a significant overlap between these files
+                    // and other files we'll be downloading
+                    uncached_download(&file.url, &file.sha256, &download_path, |_| {}, |_| {})
+                        .await
+                        .unwrap();
+
+                    &download_path
+                };
+
+                // Extract the file (zip, tar, tar.gz)
+                extract(download_path, &target_dir).await;
+            }))
+        }
+
+        // Wait for all the downloads and extractions
+        for handle in handles {
+            handle.await.unwrap();
+        }
+    }).await;
+}
+
+// TODO: make this more robust
+fn is_file_path(input: &str) -> bool {
+    match Url::parse(input) {
+        Ok(parsed) => match parsed.scheme() {
+            "file" => true,
+            _ => false,
+        },
+        // This is a file
+        Err(ParseError::RelativeUrlWithoutBase) => true,
+        Err(e) => panic!("{e:?}"),
+    }
+}
+
+/// Structs for the json blob representing a runner available for download
+/// See `docs/specification/runner.md` for more details
+#[derive(Serialize)]
+pub struct DownloadInfo {
+    pub runner_name: String,
+    pub id: String,
+    pub framework_version: semver::Version,
+    pub runner_compat_version: u64,
+    pub runner_interface_version: u64,
+    pub runner_release_date: DateTime<Utc>,
+
+    pub download_info: Vec<DownloadItem>,
+
+    // A target triple
+    pub platform: String,
+}
+
+#[derive(Serialize)]
+pub struct DownloadItem {
+    pub url: String,
+    pub sha256: String,
+    pub relative_path: String,
+}

--- a/source/carton-runner-py/Cargo.toml
+++ b/source/carton-runner-py/Cargo.toml
@@ -34,3 +34,5 @@ carton = { path = "../carton" }
 semver = {version = "1.0.16"}
 target-lexicon = "0.12.5"
 escargot = "0.5.7"
+carton-runner-packager = { path = "../carton-runner-packager" }
+pyo3 = { features = ["auto-initialize"] }

--- a/source/carton-runner-py/build.rs
+++ b/source/carton-runner-py/build.rs
@@ -1,16 +1,3 @@
-use std::path::PathBuf;
-
 fn main() {
-    // Find the python lib dir to add to LD_LIBRARY_PATH
-    let config_file_path =
-        PathBuf::from(std::env::var("PYO3_CONFIG_FILE").expect("PYO3_CONFIG_FILE should be set"));
-    let config = std::fs::read_to_string(config_file_path).unwrap();
-    let libdir = config
-        .lines()
-        .into_iter()
-        .find_map(|line| line.strip_prefix("lib_dir="))
-        .unwrap();
-
-    println!("cargo:rerun-if-env-changed=PYO3_CONFIG_FILE");
-    println!("cargo:rustc-env=LD_LIBRARY_PATH={libdir}");
+    println!("cargo:rustc-link-arg=-Wl,-rpath,$ORIGIN/bundled_python/python/lib");
 }

--- a/source/carton-runner-py/src/env.rs
+++ b/source/carton-runner-py/src/env.rs
@@ -73,16 +73,12 @@ mod tests {
 
     #[test]
     fn get_current_environment() {
-        crate::python_utils::init();
-
         let env = EnvironmentMarkers::get_current().unwrap();
         println!("{:#?}", env);
     }
 
     #[test]
     fn serailize_empty() {
-        crate::python_utils::init();
-
         let env = EnvironmentMarkers::default();
         let serialized = toml::to_string_pretty(&env).unwrap();
         assert!(serialized.is_empty())

--- a/source/carton-runner-py/src/packager.rs
+++ b/source/carton-runner-py/src/packager.rs
@@ -321,8 +321,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_generate_lockfile() {
-        crate::python_utils::init();
-
         let tempdir = tempfile::tempdir().unwrap();
 
         let requirements_file_path = tempdir.path().join("requirements.txt");

--- a/source/carton-runner-py/src/pip_utils.rs
+++ b/source/carton-runner-py/src/pip_utils.rs
@@ -119,8 +119,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_lightgbm_deps() {
-        crate::python_utils::init();
-
         let tempdir = tempfile::tempdir().unwrap();
 
         let requirements_file_path = tempdir.path().join("requirements.txt");
@@ -152,8 +150,6 @@ mod tests {
     /// Ensure that the correct version of pip is available in subprocesses
     #[tokio::test]
     async fn test_pip_subprocess_version() {
-        crate::python_utils::init();
-
         ensure_has_pip().await;
 
         let output = Command::new(get_executable_path().unwrap().as_str())

--- a/source/carton-runner-py/src/wheel.rs
+++ b/source/carton-runner-py/src/wheel.rs
@@ -70,7 +70,7 @@ pub async fn install_wheel(url: &str, sha256: &str) -> PathBuf {
         .without_progress();
 
     // Unzip
-    with_atomic_extraction(&download_path, &target_dir, extract_zip).await;
+    with_atomic_extraction(&target_dir, |out_dir| extract_zip(download_path, out_dir)).await;
 
     sl.done();
 
@@ -88,8 +88,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_install_pip() {
-        crate::python_utils::init();
-
         let out = install_wheel(
             "https://files.pythonhosted.org/packages/ab/43/508c403c38eeaa5fc86516eb13bb470ce77601b6d2bbcdb16e26328d0a15/pip-23.0-py3-none-any.whl",
             "b5f88adff801f5ef052bcdef3daa31b55eb67b0fccd6d0106c206fa248e0463c"
@@ -105,8 +103,6 @@ mod tests {
     /// Ensure that wheels that we make available in this process are also available in subprocesses
     #[tokio::test]
     async fn test_install_pip_subprocess() {
-        crate::python_utils::init();
-
         install_wheel_and_make_available(
             "https://files.pythonhosted.org/packages/ab/43/508c403c38eeaa5fc86516eb13bb470ce77601b6d2bbcdb16e26328d0a15/pip-23.0-py3-none-any.whl",
             "b5f88adff801f5ef052bcdef3daa31b55eb67b0fccd6d0106c206fa248e0463c"

--- a/source/carton-utils/src/download.rs
+++ b/source/carton-utils/src/download.rs
@@ -1,6 +1,6 @@
 use lazy_static::lazy_static;
 use sha2::{Digest, Sha256};
-use std::{future::Future, path::Path};
+use std::path::Path;
 
 use crate::error::{DownloadError, Result};
 

--- a/source/carton/Cargo.toml
+++ b/source/carton/Cargo.toml
@@ -28,9 +28,8 @@ sha2 = "0.10.6"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 nvml-wrapper = "0.8.0"
-walkdir = "2.3.2"
-futures = "0.3"
 lunchbox = { version = "0.1", features = ["serde", "localfs"]}
+carton-runner-packager = { path = "../carton-runner-packager" }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 lunchbox = { version = "0.1", features = ["serde"]}

--- a/source/carton/src/lib.rs
+++ b/source/carton/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod carton;
 mod conversion_utils;
 pub mod error;
 mod format;
@@ -6,9 +7,4 @@ pub mod info;
 mod load;
 mod runner_interface;
 pub mod types;
-
-#[cfg(not(target_family = "wasm"))]
-mod discovery;
-
-pub mod carton;
 pub use crate::carton::Carton;

--- a/source/carton/src/load.rs
+++ b/source/carton/src/load.rs
@@ -160,12 +160,12 @@ where
 pub(crate) async fn discover_or_get_runner_and_launch<T>(
     info: &CartonInfo<T>,
     visible_device: &Device,
-) -> crate::error::Result<(Runner, crate::discovery::RunnerInfo)>
+) -> crate::error::Result<(Runner, carton_runner_packager::discovery::RunnerInfo)>
 where
     T: TensorStorage,
 {
     // TODO: maybe we want to just do this once at startup or cache it?
-    let local_runners = crate::discovery::discover_runners().await;
+    let local_runners = carton_runner_packager::discovery::discover_runners().await;
 
     // Filter the runners to ones that match our requirements
     let candidate = local_runners


### PR DESCRIPTION
This PR creates a `carton-runner-packager` crate that can package, install, and discover runners.

It also updates the `load_unpacked` test in `carton-runner-py` to package and install the runner built against a specific version of python.

