### PR TITLE
Build releases for the python runner and add it to CI

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,34 @@
+name: Runner Releases
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  runner_release_native:
+    name: Native Build ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.ZIPFS_READ }}
+          submodules: recursive
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build --release --verbose
+      - run: cargo test --release --verbose
+      - name: Build runners
+        run: rm -rf /tmp/runner_releases && mkdir -p /tmp/runner_releases && cargo run --release -p carton-runner-py --bin build_releases -- --output-path /tmp/runner_releases
+      - name: Upload runners
+        uses: actions/upload-artifact@v3
+        with:
+          name: runners
+          path: /tmp/runner_releases

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,6 +401,7 @@ dependencies = [
  "carton-runner-interface",
  "carton-runner-packager",
  "carton-utils",
+ "clap 4.1.1",
  "escargot",
  "findshlibs",
  "flate2",

--- a/source/carton-runner-py/Cargo.toml
+++ b/source/carton-runner-py/Cargo.toml
@@ -28,13 +28,16 @@ lunchbox = { version = "0.1", features = ["serde"], default-features = false }
 bytesize = {version = "1.1.0"}
 findshlibs = "0.10.2"
 
-[dev-dependencies]
-lunchbox = { version = "0.1", features = ["serde", "localfs"] }
-carton = { path = "../carton" }
+# Used by the `build_releases` binary
 semver = {version = "1.0.16"}
 target-lexicon = "0.12.5"
 escargot = "0.5.7"
 carton-runner-packager = { path = "../carton-runner-packager" }
+clap = { version = "4.0.29", features = ["derive"] }
+
+[dev-dependencies]
+lunchbox = { version = "0.1", features = ["serde", "localfs"] }
+carton = { path = "../carton" }
 pyo3 = { features = ["auto-initialize"] }
 
 [build-dependencies]

--- a/source/carton-runner-py/build.rs
+++ b/source/carton-runner-py/build.rs
@@ -16,13 +16,8 @@ fn main() {
     println!("cargo:rustc-link-arg=-Wl,-rpath,$ORIGIN/bundled_python/python/lib");
 }
 
-struct PythonVersion {
-    major: u32,
-    minor: u32,
-    micro: u32,
-    url: &'static str,
-    sha256: &'static str,
-}
+// Include the list of python releases we want to build against
+include!("src/bin/build_releases/python_versions.rs");
 
 /// Install standalone python builds
 #[tokio::main]
@@ -32,44 +27,13 @@ pub async fn install_python() {
     let python_configs_dir = manifest_dir.join("python_configs");
     std::fs::create_dir_all(&python_configs_dir).unwrap();
 
-    let to_fetch = [
-        PythonVersion {
-            major: 3,
-            minor: 10,
-            micro: 9,
-            url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9+20230116-x86_64-unknown-linux-gnu-install_only.tar.gz",
-            sha256: "d196347aeb701a53fe2bb2b095abec38d27d0fa0443f8a1c2023a1bed6e18cdf",
-        },
-        PythonVersion {
-            major: 3,
-            minor: 11,
-            micro: 1,
-            url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1+20230116-x86_64-unknown-linux-gnu-install_only.tar.gz",
-            sha256: "02a551fefab3750effd0e156c25446547c238688a32fabde2995c941c03a6423",
-        },
-        PythonVersion {
-            major: 3,
-            minor: 8,
-            micro: 16,
-            url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.8.16+20230116-x86_64-unknown-linux-gnu-install_only.tar.gz",
-            sha256: "c890de112f1ae31283a31fefd2061d5c97bdd4d1bdd795552c7abddef2697ea1",
-        },
-        PythonVersion {
-            major: 3,
-            minor: 9,
-            micro: 16,
-            url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.9.16+20230116-x86_64-unknown-linux-gnu-install_only.tar.gz",
-            sha256: "7ba397787932393e65fc2fb9fcfabf54f2bb6751d5da2b45913cb25b2d493758",
-        },
-    ];
-
     for PythonVersion {
         major,
         minor,
         micro,
         url,
         sha256,
-    } in to_fetch
+    } in PYTHON_VERSIONS
     {
         println!("Fetching python {major}.{minor}.{micro} from {url} ({sha256})...");
         let out_dir = bundled_python_dir.join(format!("python{major}.{minor}.{micro}"));

--- a/source/carton-runner-py/src/bin/build_releases/main.rs
+++ b/source/carton-runner-py/src/bin/build_releases/main.rs
@@ -1,0 +1,84 @@
+//! A binary that builds the release packages
+
+use std::{path::PathBuf, time::SystemTime};
+
+use carton_runner_packager::{discovery::RunnerInfo, DownloadItem};
+use clap::Parser;
+use python_versions::{PythonVersion, PYTHON_VERSIONS};
+mod python_versions;
+
+#[derive(Parser, Debug)]
+struct Args {
+    /// The local folder to output to
+    #[arg(long)]
+    output_path: PathBuf,
+}
+
+#[tokio::main]
+async fn main() {
+    // Parse args
+    let args = Args::parse();
+
+    for PythonVersion {
+        url,
+        sha256,
+        major,
+        minor,
+        micro,
+    } in PYTHON_VERSIONS
+    {
+        println!("Building runner for python {major}.{minor}.{micro}");
+        let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+
+        // Build the runner for a specific version of python
+        let runner_path = escargot::CargoBuild::new()
+            .package("carton-runner-py")
+            .bin("carton-runner-py")
+            .env(
+                "PYO3_CONFIG_FILE",
+                manifest_dir.join(format!("python_configs/cpython{major}.{minor}.{micro}")),
+            )
+            .current_release()
+            .run()
+            .unwrap()
+            .path()
+            .display()
+            .to_string();
+        println!("Runner Path: {}", runner_path);
+
+        let package = carton_runner_packager::package(
+            RunnerInfo {
+                runner_name: "python".to_string(),
+                framework_version: semver::Version::new(major as _, minor as _, micro as _),
+                runner_compat_version: 1,
+                runner_interface_version: 1,
+                runner_release_date: SystemTime::now().into(),
+                runner_path,
+                platform: target_lexicon::HOST.to_string(),
+            },
+            vec![DownloadItem {
+                url: url.to_string(),
+                sha256: sha256.to_string(),
+                relative_path: "./bundled_python".to_string(),
+            }],
+        )
+        .await;
+
+        // Write the zip file to our output dir
+        let package_id = package.get_id();
+        tokio::fs::write(
+            &args.output_path.join(format!("{package_id}.zip")),
+            package.get_data(),
+        )
+        .await
+        .unwrap();
+
+        // Write the package config so it can be loaded when the runner zip files will be uploaded
+        tokio::fs::write(
+            &args.output_path.join(format!("{package_id}.json")),
+            serde_json::to_string_pretty(&package).unwrap(),
+        )
+        .await
+        .unwrap()
+    }
+}

--- a/source/carton-runner-py/src/bin/build_releases/python_versions.rs
+++ b/source/carton-runner-py/src/bin/build_releases/python_versions.rs
@@ -1,0 +1,39 @@
+pub struct PythonVersion {
+    pub major: u32,
+    pub minor: u32,
+    pub micro: u32,
+    pub url: &'static str,
+    pub sha256: &'static str,
+}
+
+/// Lists the python releases we want to build against
+pub const PYTHON_VERSIONS: [PythonVersion; 4] = [
+        PythonVersion {
+            major: 3,
+            minor: 10,
+            micro: 9,
+            url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9+20230116-x86_64-unknown-linux-gnu-install_only.tar.gz",
+            sha256: "d196347aeb701a53fe2bb2b095abec38d27d0fa0443f8a1c2023a1bed6e18cdf",
+        },
+        PythonVersion {
+            major: 3,
+            minor: 11,
+            micro: 1,
+            url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1+20230116-x86_64-unknown-linux-gnu-install_only.tar.gz",
+            sha256: "02a551fefab3750effd0e156c25446547c238688a32fabde2995c941c03a6423",
+        },
+        PythonVersion {
+            major: 3,
+            minor: 8,
+            micro: 16,
+            url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.8.16+20230116-x86_64-unknown-linux-gnu-install_only.tar.gz",
+            sha256: "c890de112f1ae31283a31fefd2061d5c97bdd4d1bdd795552c7abddef2697ea1",
+        },
+        PythonVersion {
+            major: 3,
+            minor: 9,
+            micro: 16,
+            url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.9.16+20230116-x86_64-unknown-linux-gnu-install_only.tar.gz",
+            sha256: "7ba397787932393e65fc2fb9fcfabf54f2bb6751d5da2b45913cb25b2d493758",
+        },
+    ];


### PR DESCRIPTION
This PR adds a binary to `carton-runner-py` that can build releases of the runner for several versions of Python. It also runs that binary nightly in CI.

 As part of this, the PR refactors some code in `carton-runner-packager` to make it easier to use in a release workflow.