### PR TITLE
Initial support for macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os:
-          - ubuntu-latest
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: macos-latest
+            target: x86_64-apple-darwin
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -34,8 +37,8 @@ jobs:
           token: ${{ secrets.ZIPFS_READ }}
           submodules: recursive
       - uses: Swatinem/rust-cache@v2
-      - run: cargo build --verbose
-      - run: cargo test --verbose
+      - run: cargo build --verbose --target ${{ matrix.target }}
+      - run: cargo test --verbose --target ${{ matrix.target }}
       - name: Upload `carton_logs` on failure
         if: ${{ failure() }}
         uses: actions/upload-artifact@v3

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,8 +14,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os:
-          - ubuntu-latest
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: macos-latest
+            target: x86_64-apple-darwin
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -23,8 +26,8 @@ jobs:
           token: ${{ secrets.ZIPFS_READ }}
           submodules: recursive
       - uses: Swatinem/rust-cache@v2
-      - run: cargo build --release --verbose
-      - run: cargo test --release --verbose
+      - run: cargo build --release --verbose --target ${{ matrix.target }}
+      - run: cargo test --release --verbose --target ${{ matrix.target }}
       - name: Build runners
         run: rm -rf /tmp/runner_releases && mkdir -p /tmp/runner_releases && cargo run --release -p carton-runner-py --bin build_releases -- --output-path /tmp/runner_releases
       - name: Upload runners

--- a/source/carton-bindings-py/build.rs
+++ b/source/carton-bindings-py/build.rs
@@ -1,0 +1,9 @@
+fn main() {
+    // Rerun only if this file changes (otherwise cargo would rerun this build script all the time)
+    println!("cargo:rerun-if-changed=build.rs");
+
+    #[cfg(target_os = "macos")]
+    println!(
+        "cargo:rustc-link-arg=-Wl,-rpath,/Library/Developer/CommandLineTools/Library/Frameworks"
+    );
+}

--- a/source/carton-runner-interface/src/server.rs
+++ b/source/carton-runner-interface/src/server.rs
@@ -297,8 +297,9 @@ pub async fn init_runner() -> Server {
     // NOTE: this technically shuts down if the thread that forked this process dies, but since
     // the parent should be running in tokio, this should be okay because if the parent's tokio
     // runtime goes down, we should go down.
-    let res = unsafe { libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGKILL) };
-    if res != 0 {
+    // TODO: add an alternative on mac
+    #[cfg(not(target_os = "macos"))]
+    if unsafe { libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGKILL) } != 0 {
         panic!("prctl failed")
     }
 

--- a/source/carton-runner-py/build.rs
+++ b/source/carton-runner-py/build.rs
@@ -13,7 +13,16 @@ fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 
     // Add the bundled python lib dir to the binary's rpath
+    #[cfg(not(target_os = "macos"))]
     println!("cargo:rustc-link-arg=-Wl,-rpath,$ORIGIN/bundled_python/python/lib");
+
+    #[cfg(target_os = "macos")]
+    println!("cargo:rustc-link-arg=-Wl,-rpath,@loader_path/bundled_python/python/lib");
+
+    #[cfg(target_os = "macos")]
+    println!(
+        "cargo:rustc-link-arg=-Wl,-rpath,/Library/Developer/CommandLineTools/Library/Frameworks"
+    );
 }
 
 // Include the list of python releases we want to build against

--- a/source/carton-runner-py/src/bin/build_releases/python_versions.rs
+++ b/source/carton-runner-py/src/bin/build_releases/python_versions.rs
@@ -7,6 +7,7 @@ pub struct PythonVersion {
 }
 
 /// Lists the python releases we want to build against
+#[cfg(not(target_os = "macos"))]
 pub const PYTHON_VERSIONS: [PythonVersion; 4] = [
         PythonVersion {
             major: 3,
@@ -35,5 +36,71 @@ pub const PYTHON_VERSIONS: [PythonVersion; 4] = [
             micro: 16,
             url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.9.16+20230116-x86_64-unknown-linux-gnu-install_only.tar.gz",
             sha256: "7ba397787932393e65fc2fb9fcfabf54f2bb6751d5da2b45913cb25b2d493758",
+        },
+    ];
+
+/// Lists the python releases we want to build against
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+pub const PYTHON_VERSIONS: [PythonVersion; 4] = [
+        PythonVersion {
+            major: 3,
+            minor: 10,
+            micro: 9,
+            url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9+20230116-aarch64-apple-darwin-install_only.tar.gz",
+            sha256: "018d05a779b2de7a476f3b3ff2d10f503d69d14efcedd0774e6dab8c22ef84ff",
+        },
+        PythonVersion {
+            major: 3,
+            minor: 11,
+            micro: 1,
+            url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1+20230116-aarch64-apple-darwin-install_only.tar.gz",
+            sha256: "4918cdf1cab742a90f85318f88b8122aeaa2d04705803c7b6e78e81a3dd40f80",
+        },
+        PythonVersion {
+            major: 3,
+            minor: 8,
+            micro: 16,
+            url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.8.16+20230116-aarch64-apple-darwin-install_only.tar.gz",
+            sha256: "d1f408569d8807c1053939d7822b082a17545e363697e1ce3cfb1ee75834c7be",
+        },
+        PythonVersion {
+            major: 3,
+            minor: 9,
+            micro: 16,
+            url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.9.16+20230116-aarch64-apple-darwin-install_only.tar.gz",
+            sha256: "d732d212d42315ac27c6da3e0b69636737a8d72086c980daf844344c010cab80",
+        },
+    ];
+
+/// Lists the python releases we want to build against
+#[cfg(all(target_os = "macos", target_arch = "x86_64"))]
+pub const PYTHON_VERSIONS: [PythonVersion; 4] = [
+        PythonVersion {
+            major: 3,
+            minor: 10,
+            micro: 9,
+            url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9+20230116-x86_64-apple-darwin-install_only.tar.gz",
+            sha256: "0e685f98dce0e5bc8da93c7081f4e6c10219792e223e4b5886730fd73a7ba4c6",
+        },
+        PythonVersion {
+            major: 3,
+            minor: 11,
+            micro: 1,
+            url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1+20230116-x86_64-apple-darwin-install_only.tar.gz",
+            sha256: "20a4203d069dc9b710f70b09e7da2ce6f473d6b1110f9535fb6f4c469ed54733",
+        },
+        PythonVersion {
+            major: 3,
+            minor: 8,
+            micro: 16,
+            url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.8.16+20230116-x86_64-apple-darwin-install_only.tar.gz",
+            sha256: "484ba901f64fc7888bec5994eb49343dc3f9d00ed43df17ee9c40935aad4aa18",
+        },
+        PythonVersion {
+            major: 3,
+            minor: 9,
+            micro: 16,
+            url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.9.16+20230116-x86_64-apple-darwin-install_only.tar.gz",
+            sha256: "3948384af5e8d4ee7e5ccc648322b99c1c5cf4979954ed5e6b3382c69d6db71e",
         },
     ];

--- a/source/carton-runner-py/src/python_utils.rs
+++ b/source/carton-runner-py/src/python_utils.rs
@@ -70,8 +70,15 @@ fn init_inner() {
     });
 }
 
+#[cfg(not(all(test, target_os = "macos")))]
 pub(crate) fn get_executable_path() -> PyResult<String> {
     Python::with_gil(|py| Python::import(py, "sys")?.getattr("executable")?.extract())
+}
+
+// TODO: make this more generic
+#[cfg(all(test, target_os = "macos"))]
+pub(crate) fn get_executable_path() -> PyResult<String> {
+    Ok("/Applications/Xcode.app/Contents/Developer/usr/bin/python3".into())
 }
 
 /// Adds a vec of paths to sys.path


### PR DESCRIPTION
This PR adds initial support for macOS and adds x86_64 mac builds to CI.

I also ran tests locally on an M1 mac. `aarch64-apple-darwin` builds will be added to CI in the future (either via cross compilation/universal builds or via another CI provider)