### PR TITLE
Temporarily disable macOS builds on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,10 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-          - os: macos-latest
-            target: x86_64-apple-darwin
+          # For now, don't run macos builds on every commit.
+          # TODO: reenable this when the repo is public
+          # - os: macos-latest
+          #   target: x86_64-apple-darwin
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,9 +29,9 @@ jobs:
       - run: cargo build --release --verbose --target ${{ matrix.target }}
       - run: cargo test --release --verbose --target ${{ matrix.target }}
       - name: Build runners
-        run: rm -rf /tmp/runner_releases && mkdir -p /tmp/runner_releases && cargo run --release -p carton-runner-py --bin build_releases -- --output-path /tmp/runner_releases
+        run: rm -rf /tmp/runner_releases && mkdir -p /tmp/runner_releases && cargo run --release  --target ${{ matrix.target }} -p carton-runner-py --bin build_releases -- --output-path /tmp/runner_releases
       - name: Upload runners
         uses: actions/upload-artifact@v3
         with:
-          name: runners
+          name: runners-${{ matrix.target }}
           path: /tmp/runner_releases


### PR DESCRIPTION
macOS CI builds use up [10x the GitHub Actions minutes](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#minute-multipliers) as Linux builds.

Because of this, this PR temporarily disables macOS builds on every PR. This can be reenabled once the repo is public.

This PR also modifies the nightly macOS build to correctly build artifacts.