### PR TITLE
Upload nightly releases from CI

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -56,3 +56,27 @@ jobs:
         with:
           name: runners-aarch64
           path: /tmp/runner_releases
+
+  upload_nightly_builds:
+    name: "Upload nightly builds"
+    needs: [runner_release_native, runner_release_aarch64]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.ZIPFS_READ }}
+          submodules: recursive
+      - run: mkdir /tmp/artifacts
+      - uses: actions/download-artifact@v3
+        with:
+          path: /tmp/artifacts
+      - name: Upload artifacts and generate config
+        run: cargo run --package carton-runner-packager --bin ci_upload_releases
+        env:
+          NIGHTLY_REPO_TOKEN: ${{ secrets.NIGHTLY_REPO_TOKEN }}
+          CARTON_NIGHTLY_S3_BUCKET: ${{ vars.CARTON_NIGHTLY_S3_BUCKET }}
+          CARTON_NIGHTLY_S3_REGION: ${{ vars.CARTON_NIGHTLY_S3_REGION }}
+          CARTON_NIGHTLY_S3_ENDPOINT: ${{ secrets.CARTON_NIGHTLY_S3_ENDPOINT }}
+          CARTON_NIGHTLY_ACCESS_KEY_ID: ${{ secrets.CARTON_NIGHTLY_ACCESS_KEY_ID }}
+          CARTON_NIGHTLY_SECRET_ACCESS_KEY: ${{ secrets.CARTON_NIGHTLY_SECRET_ACCESS_KEY }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,6 +132,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "attohttpc"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "262c3f7f5d61249d8c00e5546e2685cd15ebeeb1bc0f3cc5449350a1cb07319e"
+dependencies = [
+ "http",
+ "log",
+ "native-tls",
+ "openssl",
+ "serde",
+ "serde_json",
+ "url",
+ "wildmatch",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -147,6 +163,31 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "aws-creds"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeeee1a5defa63cba39097a510dfe63ef53658fc8995202a610f6a8a4d03639"
+dependencies = [
+ "attohttpc",
+ "dirs",
+ "rust-ini",
+ "serde",
+ "serde-xml-rs",
+ "thiserror",
+ "time 0.3.19",
+ "url",
+]
+
+[[package]]
+name = "aws-region"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f92a8af5850d0ea0916ca3e015ab86951ded0bf4b70fd27896e81ae1dfb0af37"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "axum"
@@ -199,6 +240,12 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "bincode"
@@ -371,12 +418,14 @@ name = "carton-runner-packager"
 version = "0.0.1"
 dependencies = [
  "async_zip",
+ "base64 0.21.0",
  "carton-utils",
  "chrono",
  "escargot",
  "futures",
  "log",
  "reqwest",
+ "rust-s3",
  "semver 1.0.16",
  "serde",
  "serde_json",
@@ -490,7 +539,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "time",
+ "time 0.1.45",
  "wasm-bindgen",
  "winapi",
 ]
@@ -851,7 +900,34 @@ checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
+
+[[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
 
 [[package]]
 name = "either"
@@ -1127,6 +1203,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hdrhistogram"
@@ -1134,7 +1213,7 @@ version = "7.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f19b9f54f7c7f55e31401bb647626ce0cf0f67b0004982ce815b3ee72a02aa8"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "byteorder",
  "flate2",
  "nom",
@@ -1163,6 +1242,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -1520,6 +1614,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "maybe-async"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f1b8c13cb1f814b634a96b2c725449fe7ed464a7b8781de8688be5ffbd3f305"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1548,6 +1659,15 @@ name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "minidom"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e9ce45d459e358790a285e7609ff5ae4cfab88b75f237e8838e62029dda397b"
+dependencies = [
+ "rxml",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -1790,6 +1910,16 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "ordered-multimap"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
+dependencies = [
+ "dlv-list",
+ "hashbrown",
 ]
 
 [[package]]
@@ -2139,6 +2269,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2188,7 +2329,7 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2211,12 +2352,54 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
  "winreg",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6d5f2436026b4f6e79dc829837d467cc7e9a55ee40e750d716713540715a2df"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
+]
+
+[[package]]
+name = "rust-s3"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6009d9d4cf910505534d62d380a0aa305805a2af0b5c3ad59a3024a0715b847"
+dependencies = [
+ "async-trait",
+ "aws-creds",
+ "aws-region",
+ "base64 0.13.1",
+ "cfg-if",
+ "hex",
+ "hmac",
+ "http",
+ "log",
+ "maybe-async",
+ "md5",
+ "minidom",
+ "percent-encoding",
+ "reqwest",
+ "serde",
+ "serde-xml-rs",
+ "serde_derive",
+ "sha2",
+ "thiserror",
+ "time 0.3.19",
+ "tokio",
+ "tokio-stream",
+ "url",
 ]
 
 [[package]]
@@ -2238,6 +2421,25 @@ name = "rustversion"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
+
+[[package]]
+name = "rxml"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a071866b8c681dc2cfffa77184adc32b57b0caad4e620b6292609703bceb804"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "rxml_validation",
+ "smartstring",
+ "tokio",
+]
+
+[[package]]
+name = "rxml_validation"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53bc79743f9a66c2fb1f951cd83735f275d46bfe466259fbc5897bb60a0d00ee"
 
 [[package]]
 name = "ryu"
@@ -2343,6 +2545,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-xml-rs"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65162e9059be2f6a3421ebbb4fef3e74b7d9e7c60c50a0e292c6239f19f1edfa"
+dependencies = [
+ "log",
+ "serde",
+ "thiserror",
+ "xml-rs",
+]
+
+[[package]]
 name = "serde_bytes"
 version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2430,6 +2644,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
+name = "smartstring"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e714dff2b33f2321fdcd475b71cec79781a692d846f37f415fb395a1d2bcd48e"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
 name = "socket2"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2456,6 +2679,12 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
@@ -2569,6 +2798,33 @@ dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
+]
+
+[[package]]
+name = "time"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53250a3b3fed8ff8fd988587d8925d26a83ac3845d9e03b220b37f34c2b8d6c2"
+dependencies = [
+ "itoa",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+
+[[package]]
+name = "time-macros"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a460aeb8de6dcb0f381e1ee05f1cd56fcf5a5f6eb8187ff3d8f0b11078d38b7c"
+dependencies = [
+ "time-core",
 ]
 
 [[package]]
@@ -2691,7 +2947,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64",
+ "base64 0.13.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -3027,6 +3283,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wildmatch"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee583bdc5ff1cf9db20e9db5bb3ff4c3089a8f6b8b31aff265c9aba85812db86"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3186,6 +3448,12 @@ checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "xml-rs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
 
 [[package]]
 name = "xz2"

--- a/source/carton-runner-packager/Cargo.toml
+++ b/source/carton-runner-packager/Cargo.toml
@@ -12,7 +12,7 @@ serde_json = "1"
 url = "2.3.1"
 log = "0.4"
 escargot = "0.5.7"
-semver = {version = "1.0.16"}
+semver = {version = "1.0.16", features = ["serde"]}
 target-lexicon = "0.12.5"
 chrono = {version = "0.4.23", features = ["serde"]}
 tempfile = "3.3.0"
@@ -22,3 +22,8 @@ sha2 = "0.10.6"
 walkdir = "2.3.2"
 futures = "0.3"
 thiserror = "1"
+base64 = "0.21.0"
+
+# Required by ci_upload_releases
+# TODO: split this out
+rust-s3 = "0.32.3"

--- a/source/carton-runner-packager/src/bin/ci_upload_releases.rs
+++ b/source/carton-runner-packager/src/bin/ci_upload_releases.rs
@@ -1,0 +1,181 @@
+//! A binary that uploads nightly releases. Used in CI
+
+use std::{cmp::Reverse, sync::Arc};
+
+use base64::Engine;
+use carton_runner_packager::{DownloadInfo, RunnerPackage};
+use s3::{creds::Credentials, Bucket, Region};
+use serde::{Deserialize, Serialize};
+
+#[tokio::main]
+async fn main() {
+    let API_KEY = std::env::var("NIGHTLY_REPO_TOKEN").expect("NIGHTLY_REPO_TOKEN should be in env");
+
+    // First, get the current config and its blob sha
+    let client = reqwest::Client::new();
+    let res = client
+        .get("https://api.github.com/repos/vivekpanyam/carton-nightly/contents/v1/runners")
+        .header("Authorization", format!("Bearer {API_KEY}"))
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .header("Accept", "application/vnd.github.object")
+        .header("User-Agent", "Carton-Nightly-Build")
+        .send()
+        .await
+        .unwrap();
+
+    if res.status() != 200 {
+        panic!(
+            "Got non-200 status: {}. Contents: {}",
+            res.status(),
+            res.text().await.unwrap()
+        );
+    }
+
+    // Parse the object response
+    // https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28
+    #[derive(Deserialize, Debug)]
+    struct GHResponse {
+        content: String,
+        sha: String,
+    }
+
+    let github_response: GHResponse = res.json().await.unwrap();
+    if github_response.content == "" {
+        panic!("The github response content was empty. This likely means the runners file is > 1mb. See the GH API docs for more details.")
+    }
+
+    // Decode the runners file
+    let contents = base64::engine::general_purpose::STANDARD
+        .decode(github_response.content.trim())
+        .unwrap();
+    let mut runners: Vec<DownloadInfo> = serde_json::from_slice(&contents).unwrap();
+
+    // Get the bucket to upload to
+    let bucket = Arc::new(
+        Bucket::new(
+            &std::env::var("CARTON_NIGHTLY_S3_BUCKET").unwrap(),
+            Region::Custom {
+                region: std::env::var("CARTON_NIGHTLY_S3_REGION").unwrap(),
+                endpoint: std::env::var("CARTON_NIGHTLY_S3_ENDPOINT").unwrap(),
+            },
+            Credentials::new(
+                Some(&std::env::var("CARTON_NIGHTLY_ACCESS_KEY_ID").unwrap()),
+                Some(&std::env::var("CARTON_NIGHTLY_SECRET_ACCESS_KEY").unwrap()),
+                None,
+                None,
+                None,
+            )
+            .unwrap(),
+        )
+        .unwrap(),
+    );
+
+    // Get all the artifact dirs in /tmp/artifacts
+    let handles = std::fs::read_dir("/tmp/artifacts")
+        .unwrap()
+        .into_iter()
+        .flat_map(|artifact_dir| {
+            let artifact_dir = artifact_dir.unwrap();
+
+            // Get all the packages in this dir
+            std::fs::read_dir(&artifact_dir.path())
+                .unwrap()
+                .filter_map(move |item| {
+                    if let Ok(item) = item {
+                        if item.file_name().to_str().unwrap().ends_with(".json") {
+                            // Read the config
+                            let package: RunnerPackage =
+                                serde_json::from_slice(&std::fs::read(item.path()).unwrap())
+                                    .unwrap();
+
+                            // Get the zipfile path
+                            let zipfile_path = artifact_dir
+                                .path()
+                                .join(format!("{}.zip", package.get_data_sha256()));
+
+                            return Some((zipfile_path, package));
+                        }
+                    }
+
+                    None
+                })
+        })
+        .map(|(zip_path, package)| {
+            let bucket = bucket.clone();
+            tokio::spawn(async move {
+                let content = tokio::fs::read(zip_path).await.unwrap();
+
+                // Upload the zip file
+                bucket
+                    .put_object(format!("/{}", package.get_data_sha256()), &content)
+                    .await
+                    .unwrap();
+
+                // Get the download_info
+                let url = format!(
+                    "https://nightly-assets.carton.run/{}",
+                    package.get_data_sha256()
+                );
+
+                package.get_download_info(url)
+            })
+        });
+
+    // Wait for the uploads to complete and then insert the runners
+    for handle in handles {
+        runners.insert(0, handle.await.unwrap());
+    }
+
+    // Sort in descending order
+    runners.sort_by_key(|item| Reverse(item.runner_release_date));
+
+    // Serialize
+    let new_contents = serde_json::to_string_pretty(&runners).unwrap();
+
+    // Upload
+    // https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28
+    #[derive(Serialize, Debug)]
+    struct GHUpload {
+        message: String,
+        content: String,
+        sha: String,
+        committer: GHAuthor,
+    }
+
+    #[derive(Serialize, Debug)]
+    struct GHAuthor {
+        name: &'static str,
+        email: &'static str,
+    }
+
+    let to_upload = GHUpload {
+        message: "Update nightly runners".to_string(),
+        content: base64::engine::general_purpose::STANDARD.encode(new_contents),
+
+        // The previous file's sha
+        sha: github_response.sha,
+        committer: GHAuthor {
+            name: "CartonBot",
+            email: "bot@carton.run",
+        },
+    };
+
+    let res = client
+        .put("https://api.github.com/repos/vivekpanyam/carton-nightly/contents/v1/runners")
+        .header("Authorization", format!("Bearer {API_KEY}"))
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .header("Accept", "application/vnd.github+json")
+        .header("User-Agent", "Carton-Nightly-Build")
+        .body(serde_json::to_string(&to_upload).unwrap())
+        .send()
+        .await
+        .unwrap();
+
+    if res.status() != 200 {
+        panic!(
+            "Got non-200 status when updating runners file: {}. Contents: {}",
+            res.status(),
+            res.text().await.unwrap()
+        );
+    }
+}


### PR DESCRIPTION
This PR adds a job to the nightly GitHub actions build that uploads all the artifacts to static storage and updates the download information in https://github.com/VivekPanyam/carton-nightly/

This information will be fetched by carton when it's looking for runners to install

## Test Plan

Ran the nightly workflow on another branch and verified that everything worked as expected.