### PR TITLE
Run Linux CI builds in `manylinux2014` containers

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,8 +3,6 @@ only_if: $CIRRUS_TAG == '' && ($CIRRUS_PR != '' || $CIRRUS_BRANCH == 'main')
 env:
   CARGO_TERM_COLOR: always
   CIRRUS_REPO_CLONE_TOKEN: ENCRYPTED[dd171eb99e384bce7789885bbe284ef3b59ae7aa37956f1c03d54074b064055d3754842f9688e4d494d01e8229a3e9eb]
-  # This defaults to /tmp which causes CrossesDevices errors when we try to rename temp files
-  CIRRUS_VOLUME: /something
 
 linux_task:
   name: Native Build aarch64-unknown-linux-gnu

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
   build_and_test_native:
     name: Native Build ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    container:
+      # TODO: only on linux
+      image: vpanyam/manylinux2014-rust-python310:x86_64
     strategy:
       matrix:
         include:
@@ -38,6 +41,7 @@ jobs:
         with:
           token: ${{ secrets.ZIPFS_READ }}
           submodules: recursive
+      - run: rustup default stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo build --verbose --target ${{ matrix.target }}
       - run: cargo test --verbose --target ${{ matrix.target }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,6 +12,9 @@ jobs:
   runner_release_native:
     name: Native Build ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    container:
+      # TODO: only on linux
+      image: vpanyam/manylinux2014-rust-python310:x86_64
     strategy:
       matrix:
         include:
@@ -27,6 +30,7 @@ jobs:
         with:
           token: ${{ secrets.ZIPFS_READ }}
           submodules: recursive
+      - run: rustup default stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo build --release --verbose --target ${{ matrix.target }}
       - run: cargo test --release --verbose --target ${{ matrix.target }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1900,6 +1900,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "111.25.0+1.1.1t"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3173cd3626c43e3854b1b727422a276e568d9ec5fe8cec197822cf52cfb743d6"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1908,6 +1917,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/ci/cirrus_ci.dockerfile
+++ b/ci/cirrus_ci.dockerfile
@@ -1,7 +1,16 @@
 # A dockerfile for cirrusci builds
 
-# Start with the official rust image
-FROM rust:latest
+# Start with the manylinux2014 image
+FROM quay.io/pypa/manylinux2014_aarch64
 
-# Install python3 dev
-RUN apt-get update && apt-get install -y python3-dev && rm -rf /var/lib/apt/lists/*
+# Install rust
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable
+
+# Get python 3.10 (+ libs)
+RUN yum install -y wget && \
+    wget https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9+20230116-aarch64-unknown-linux-gnu-install_only.tar.gz -O python.tar.gz && \
+    tar -xvf python.tar.gz && \
+    yum clean all
+
+ENV PATH="/root/.cargo/bin:/python/bin:${PATH}"
+RUN cp /python/lib/libpython3.10.so /usr/local/lib && ldconfig

--- a/ci/trigger_cirrus_build.py
+++ b/ci/trigger_cirrus_build.py
@@ -58,8 +58,6 @@ CIRRUS_BUILD_CONFIG = """
 env:
   CARGO_TERM_COLOR: always
   CIRRUS_REPO_CLONE_TOKEN: ENCRYPTED[dd171eb99e384bce7789885bbe284ef3b59ae7aa37956f1c03d54074b064055d3754842f9688e4d494d01e8229a3e9eb]
-  # This defaults to /tmp which causes CrossesDevices errors when we try to rename temp files
-  CIRRUS_VOLUME: /something
 
 # Nightly release builds
 nightly_linux_task:

--- a/source/carton-runner-packager/Cargo.toml
+++ b/source/carton-runner-packager/Cargo.toml
@@ -16,7 +16,7 @@ semver = {version = "1.0.16", features = ["serde"]}
 target-lexicon = "0.12.5"
 chrono = {version = "0.4.23", features = ["serde"]}
 tempfile = "3.3.0"
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.11", features = ["json", "native-tls-vendored"] }
 async_zip = {version = "0.0.11", features = ["full"]}
 sha2 = "0.10.6"
 walkdir = "2.3.2"

--- a/source/carton-runner-packager/src/discovery.rs
+++ b/source/carton-runner-packager/src/discovery.rs
@@ -61,6 +61,14 @@ pub async fn discover_runners() -> Vec<RunnerInfo> {
             Some(Ok(entry)) => entry,
         };
 
+        if entry.depth() > 0
+            && entry.file_type().is_dir()
+            && entry.file_name().to_str().unwrap().starts_with(".tmp")
+        {
+            // Ignore directories that start with ".tmp" as these are in-progress extractions
+            it.skip_current_dir()
+        }
+
         if entry.file_name() == "runner.toml" {
             runner_tomls.push(entry.into_path());
 

--- a/source/carton-runner-py/Cargo.toml
+++ b/source/carton-runner-py/Cargo.toml
@@ -12,7 +12,7 @@ pyo3-asyncio = { version = "0.17", features = ["attributes", "tokio-runtime"] }
 numpy = "0.17"
 ndarray = { version = "0.15" }
 lazy_static = "1.4.0"
-reqwest = { version = "0.11" }
+reqwest = { version = "0.11", features = ["native-tls-vendored"] }
 tempfile = "3.3.0"
 home = "0.5.4"
 sha2 = "0.10.6"
@@ -41,7 +41,7 @@ carton = { path = "../carton" }
 pyo3 = { features = ["auto-initialize"] }
 
 [build-dependencies]
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.11", features = ["json", "native-tls-vendored"] }
 tokio = { version = "1", features = ["full"] }
 flate2 = "1.0"
 tar = "0.4"

--- a/source/carton-utils/Cargo.toml
+++ b/source/carton-utils/Cargo.toml
@@ -14,6 +14,6 @@ flate2 = "1.0"
 tar = "0.4"
 libc = "0.2"
 lazy_static = "1.4.0"
-reqwest = { version = "0.11" }
+reqwest = { version = "0.11", features = ["native-tls-vendored"]}
 sha2 = "0.10.6"
 thiserror = "1"

--- a/source/carton/Cargo.toml
+++ b/source/carton/Cargo.toml
@@ -17,7 +17,7 @@ toml = "0.5"
 semver = {version = "1.0.16", features = ["serde"]}
 target-lexicon = "0.12.5"
 lazy_static = "1.4.0"
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.11", features = ["json", "native-tls-vendored"] }
 bytes = "1.3.0"
 zipfs = { path = "../zipfs" }
 url = "2.3.1"


### PR DESCRIPTION
This PR makes build artifacts more portable by running all Linux CI builds in `manylinux2014` containers.