### PR TITLE
Temporarily disable scheduled nightly builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,8 +2,8 @@ name: Runner Releases
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 9 * * *'
+  # schedule:
+  #  - cron: '0 9 * * *'
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Instead of automatically running builds every night while the repo is private, I'll just manually trigger builds as necessary.