### PR TITLE
[Python Bindings] Conversions between core types and bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,12 +361,15 @@ dependencies = [
 name = "carton-bindings-py"
 version = "0.0.1"
 dependencies = [
+ "async-trait",
  "carton",
  "ndarray",
  "numpy",
  "pyo3",
  "pyo3-asyncio",
  "semver 1.0.16",
+ "target-lexicon",
+ "tokio",
 ]
 
 [[package]]
@@ -1634,18 +1637,18 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
-version = "0.6.5"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "memoffset"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg",
 ]
@@ -1815,17 +1818,17 @@ dependencies = [
 
 [[package]]
 name = "numpy"
-version = "0.17.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a462c1af5ba1fddec1488c4646993a23ae7931f9e170ccba23e9c7c834277797"
+checksum = "96b0fee4571867d318651c24f4a570c3f18408cf95f16ccb576b3ce85496a46e"
 dependencies = [
- "ahash",
  "libc",
  "ndarray",
  "num-complex",
  "num-integer",
  "num-traits",
  "pyo3",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -2115,14 +2118,14 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.17.3"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "268be0c73583c183f2b14052337465768c07726936a260f480f0857cb95ba543"
+checksum = "06a3d8e8a46ab2738109347433cb7b96dffda2e4a218b03ef27090238886b147"
 dependencies = [
  "cfg-if",
  "indoc",
  "libc",
- "memoffset 0.6.5",
+ "memoffset 0.8.0",
  "parking_lot",
  "pyo3-build-config",
  "pyo3-ffi",
@@ -2132,9 +2135,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-asyncio"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1febe3946b26194628f00526929ee6f8559f9e807f811257e94d4c456103be0e"
+checksum = "d3564762e37035cfc486228e10b0528460fa026d681b5763873c693aa0d5c260"
 dependencies = [
  "futures",
  "once_cell",
@@ -2146,9 +2149,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-asyncio-macros"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "270b167ea304b961616aa0f003463c95becd3c11a85bd83ba668fe16129e2469"
+checksum = "be72d4cd43a27530306bd0d20d3932182fbdd072c6b98d3638bc37efb9d559dd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2157,9 +2160,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.17.3"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28fcd1e73f06ec85bf3280c48c67e731d8290ad3d730f8be9dc07946923005c8"
+checksum = "75439f995d07ddfad42b192dfcf3bc66a7ecfd8b4a1f5f6f046aa5c2c5d7677d"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -2167,9 +2170,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.17.3"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6cb136e222e49115b3c51c32792886defbfb0adead26a688142b346a0b9ffc"
+checksum = "839526a5c07a17ff44823679b68add4a58004de00512a95b6c1c98a6dcac0ee5"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -2177,9 +2180,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.17.3"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94144a1266e236b1c932682136dc35a9dee8d3589728f68130c7c3861ef96b28"
+checksum = "bd44cf207476c6a9760c4653559be4f206efafb924d3e4cbf2721475fc0d6cc5"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -2189,9 +2192,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.17.3"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8df9be978a2d2f0cdebabb03206ed73b11314701a5bfe71b0d753b81997777f"
+checksum = "dc1f43d8e30460f36350d18631ccf85ded64c059829208fe680904c65bcd0a4c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2407,6 +2410,12 @@ dependencies = [
  "tokio-stream",
  "url",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"

--- a/source/carton-bindings-py/Cargo.toml
+++ b/source/carton-bindings-py/Cargo.toml
@@ -8,9 +8,12 @@ name = "cartonml"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.17.3", features = ["abi3-py37"]}
-pyo3-asyncio = { version = "0.17", features = ["attributes", "tokio-runtime"] }
+pyo3 = { version = "0.18", features = ["abi3-py37"]}
+pyo3-asyncio = { version = "0.18", features = ["attributes", "tokio-runtime"] }
 carton-core = { package = "carton", path = "../carton" }
-numpy = "0.17"
+numpy = "0.18"
 ndarray = { version = "0.15" }
 semver = {version = "1.0.16"}
+target-lexicon = "0.12.5"
+tokio = { version = "1", features = ["io-util"] }
+async-trait = "0.1"

--- a/source/carton-bindings-py/src/conversions.rs
+++ b/source/carton-bindings-py/src/conversions.rs
@@ -1,0 +1,748 @@
+//! This module implements conversions between the types in the core carton library and the ones in the python bindings
+//! Most of this is boilerplate so maybe there's a clean way to remove some portion of the code below
+use std::sync::Arc;
+use std::{collections::HashMap, str::FromStr};
+
+use async_trait::async_trait;
+use carton_core::conversion_utils::{convert_map, convert_opt_map, convert_opt_vec, convert_vec};
+use carton_core::types::{DataType, GenericStorage, RunnerOpt, Tensor};
+use numpy::ToPyArray;
+use pyo3::types::PyBytes;
+use pyo3::{exceptions::PyValueError, prelude::*, PyDowncastError};
+use semver::VersionReq;
+use target_lexicon::Triple;
+use tokio::io::AsyncReadExt;
+use tokio::sync::Mutex;
+
+use crate::tensor::{tensor_to_py, PyTensorStorage, SupportedTensorType};
+
+pub(crate) fn create_load_opts(
+    visible_device: Option<String>,
+    override_runner_name: Option<String>,
+    override_required_framework_version: Option<String>,
+    override_runner_opts: Option<HashMap<String, PyRunnerOpt>>,
+) -> PyResult<carton_core::types::LoadOpts> {
+    Ok(carton_core::types::LoadOpts {
+        override_runner_name,
+        override_required_framework_version,
+        override_runner_opts: convert_opt_map(override_runner_opts),
+        // TODO: use something more specific than ValueError
+        visible_device: match visible_device {
+            None => carton_core::types::Device::default(),
+            Some(v) => carton_core::types::Device::maybe_from_str(&v)
+                .map_err(|e| PyValueError::new_err(e.to_string()))?,
+        },
+    })
+}
+
+pub(crate) fn create_pack_opts(
+    runner_name: String,
+    required_framework_version: String,
+    runner_compat_version: Option<u64>,
+    runner_opts: Option<HashMap<String, PyRunnerOpt>>,
+    model_name: Option<String>,
+    short_description: Option<String>,
+    model_description: Option<String>,
+    required_platforms: Option<Vec<String>>,
+    inputs: Option<Vec<TensorSpec>>,
+    outputs: Option<Vec<TensorSpec>>,
+    self_tests: Option<Vec<SelfTest>>,
+    examples: Option<Vec<Example>>,
+    misc_files: Option<HashMap<String, Vec<u8>>>,
+) -> PyResult<carton_core::types::CartonInfo<PyTensorStorage>> {
+    let misc_files: Option<HashMap<String, LazyLoadedMiscFile>> = convert_opt_map(misc_files);
+
+    Ok(carton_core::types::CartonInfo {
+        model_name,
+        short_description,
+        model_description,
+        required_platforms: convert_required_platforms(required_platforms)?,
+        inputs: convert_opt_vec(inputs),
+        outputs: convert_opt_vec(outputs),
+        self_tests: convert_opt_vec(self_tests),
+        examples: convert_opt_vec(examples),
+        runner: carton_core::info::RunnerInfo {
+            runner_name,
+            required_framework_version: VersionReq::from_str(&required_framework_version).map_err(
+                |e| PyValueError::new_err(format!("Invalid `required_framework_version`: {e}")),
+            )?,
+            runner_compat_version,
+            opts: convert_opt_map(runner_opts),
+        },
+        misc_files: convert_opt_map(misc_files),
+    })
+}
+
+// Info about a carton
+#[pyclass]
+#[derive(FromPyObject, Debug)]
+pub(crate) struct CartonInfo {
+    /// The name of the model
+    #[pyo3(get)]
+    pub model_name: Option<String>,
+
+    /// A short description (should be 100 characters or less)
+    #[pyo3(get)]
+    pub short_description: Option<String>,
+
+    /// The model description
+    #[pyo3(get)]
+    pub model_description: Option<String>,
+
+    /// A list of platforms this model supports
+    /// If empty or unspecified, all platforms are okay
+    #[pyo3(get)]
+    pub required_platforms: Option<Vec<String>>,
+
+    /// A list of inputs for the model
+    /// Can be empty
+    #[pyo3(get)]
+    pub inputs: Option<Vec<TensorSpec>>,
+
+    /// A list of outputs for the model
+    /// Can be empty
+    #[pyo3(get)]
+    pub outputs: Option<Vec<TensorSpec>>,
+
+    /// Test data
+    /// Can be empty
+    #[pyo3(get)]
+    pub self_tests: Option<Vec<SelfTest>>,
+
+    /// Examples
+    /// Can be empty
+    #[pyo3(get)]
+    pub examples: Option<Vec<Example>>,
+
+    /// Information about the runner to use
+    #[pyo3(get)]
+    pub runner: RunnerInfo,
+
+    /// Misc files that can be referenced by the description. The key is a string
+    /// starting with `@misc/` followed by a normalized path (i.e one that does not
+    /// reference parent directories, etc)
+    #[pyo3(get)]
+    pub misc_files: Option<HashMap<String, LazyLoadedMiscFile>>,
+}
+
+#[pymethods]
+impl CartonInfo {
+    fn __str__(&self) -> String {
+        format!("{self:#?}")
+    }
+}
+
+fn convert_required_platforms(r: Option<Vec<String>>) -> PyResult<Option<Vec<Triple>>> {
+    Ok(match r {
+        Some(required_platforms) => {
+            let mut out = Vec::new();
+            for plat in required_platforms {
+                out.push(Triple::from_str(&plat).map_err(|e| {
+                    PyValueError::new_err(format!("Invalid value in `required_platforms`: {e}"))
+                })?)
+            }
+
+            Some(out)
+        }
+        None => None,
+    })
+}
+
+impl From<carton_core::types::CartonInfo<carton_core::types::GenericStorage>> for CartonInfo {
+    fn from(value: carton_core::types::CartonInfo<carton_core::types::GenericStorage>) -> Self {
+        Self {
+            model_name: value.model_name,
+            short_description: value.short_description,
+            model_description: value.model_description,
+            required_platforms: value.required_platforms.map(|required_platforms| {
+                required_platforms
+                    .into_iter()
+                    .map(|plat| plat.to_string())
+                    .collect()
+            }),
+            inputs: convert_opt_vec(value.inputs),
+            outputs: convert_opt_vec(value.outputs),
+            self_tests: convert_opt_vec(value.self_tests),
+            examples: convert_opt_vec(value.examples),
+            runner: RunnerInfo {
+                runner_name: value.runner.runner_name,
+                required_framework_version: value.runner.required_framework_version.to_string(),
+                runner_compat_version: value.runner.runner_compat_version,
+                opts: convert_opt_map(value.runner.opts),
+            },
+            misc_files: convert_opt_map(value.misc_files),
+        }
+    }
+}
+
+#[pyclass]
+#[derive(Clone, Debug)]
+pub(crate) struct TensorSpec {
+    #[pyo3(get, set)]
+    pub name: String,
+
+    // Note: getter and setter implemented below
+    /// The datatype
+    pub dtype: DataType,
+
+    /// Tensor shape
+    #[pyo3(get, set)]
+    pub shape: Shape,
+
+    /// Optional description
+    #[pyo3(get, set)]
+    pub description: Option<String>,
+
+    /// Optional internal name
+    #[pyo3(get, set)]
+    pub internal_name: Option<String>,
+}
+
+#[pymethods]
+impl TensorSpec {
+    #[getter]
+    fn get_dtype(&self) -> String {
+        self.dtype.to_str().to_owned()
+    }
+
+    #[setter]
+    fn set_dtype(&mut self, value: &str) -> PyResult<()> {
+        self.dtype = DataType::from_str(value).map_err(|e| PyValueError::new_err(e))?;
+
+        Ok(())
+    }
+
+    #[new]
+    fn new<'py>(
+        name: String,
+        dtype: &str,
+        shape: Shape,
+        description: Option<String>,
+    ) -> PyResult<Self> {
+        Ok(Self {
+            name,
+            dtype: DataType::from_str(dtype).map_err(|e| PyValueError::new_err(e))?,
+            shape,
+            description,
+            internal_name: None,
+        })
+    }
+}
+
+impl From<TensorSpec> for carton_core::info::TensorSpec {
+    fn from(value: TensorSpec) -> Self {
+        Self {
+            name: value.name,
+            dtype: value.dtype,
+            shape: value.shape.into(),
+            description: value.description,
+            internal_name: value.internal_name,
+        }
+    }
+}
+
+impl From<carton_core::info::TensorSpec> for TensorSpec {
+    fn from(value: carton_core::info::TensorSpec) -> Self {
+        Self {
+            name: value.name,
+            dtype: value.dtype,
+            shape: value.shape.into(),
+            description: value.description,
+            internal_name: value.internal_name,
+        }
+    }
+}
+
+#[derive(Clone, FromPyObject, Debug)]
+pub enum Shape {
+    /// Any shape
+    Any(#[pyo3(from_py_with = "handle_none")] ()),
+
+    /// A symbol for the whole shape
+    Symbol(String),
+
+    /// A list of dimensions
+    /// An empty vec is considered a scalar
+    Shape(Vec<Dimension>),
+}
+
+impl From<Shape> for carton_core::info::Shape {
+    fn from(value: Shape) -> Self {
+        match value {
+            Shape::Any(_) => Self::Any,
+            Shape::Symbol(v) => Self::Symbol(v),
+            Shape::Shape(v) => Self::Shape(convert_vec(v)),
+        }
+    }
+}
+
+impl From<carton_core::info::Shape> for Shape {
+    fn from(value: carton_core::info::Shape) -> Self {
+        match value {
+            carton_core::info::Shape::Any => Self::Any(()),
+            carton_core::info::Shape::Symbol(v) => Self::Symbol(v),
+            carton_core::info::Shape::Shape(v) => Self::Shape(convert_vec(v)),
+        }
+    }
+}
+
+impl IntoPy<PyObject> for Shape {
+    fn into_py(self, py: Python<'_>) -> PyObject {
+        match self {
+            Shape::Any(_) => Python::None(py),
+            Shape::Symbol(item) => item.into_py(py),
+            Shape::Shape(item) => item.into_py(py),
+        }
+    }
+}
+
+fn handle_none(item: &PyAny) -> PyResult<()> {
+    if item.is_none() {
+        Ok(())
+    } else {
+        Err(PyDowncastError::new(item, "None").into())
+    }
+}
+
+/// A dimension can be either a fixed value, a symbol, or any value
+#[derive(Clone, FromPyObject, Debug)]
+pub enum Dimension {
+    Value(u64),
+    Symbol(String),
+    Any(#[pyo3(from_py_with = "handle_none")] ()),
+}
+
+impl From<Dimension> for carton_core::info::Dimension {
+    fn from(value: Dimension) -> Self {
+        match value {
+            Dimension::Value(v) => Self::Value(v),
+            Dimension::Symbol(v) => Self::Symbol(v),
+            Dimension::Any(_) => Self::Any,
+        }
+    }
+}
+
+impl From<carton_core::info::Dimension> for Dimension {
+    fn from(value: carton_core::info::Dimension) -> Self {
+        match value {
+            carton_core::info::Dimension::Value(v) => Self::Value(v),
+            carton_core::info::Dimension::Symbol(v) => Self::Symbol(v),
+            carton_core::info::Dimension::Any => Self::Any(()),
+        }
+    }
+}
+
+impl IntoPy<PyObject> for Dimension {
+    fn into_py(self, py: Python<'_>) -> PyObject {
+        match self {
+            Dimension::Value(item) => item.into_py(py),
+            Dimension::Symbol(item) => item.into_py(py),
+            Dimension::Any(_) => Python::None(py),
+        }
+    }
+}
+
+#[pyclass]
+#[derive(Clone, Debug)]
+pub(crate) struct SelfTest {
+    #[pyo3(get, set)]
+    pub name: Option<String>,
+
+    #[pyo3(get, set)]
+    pub description: Option<String>,
+
+    #[pyo3(get, set)]
+    pub inputs: HashMap<String, LazyLoadedTensor>,
+
+    // Can be empty
+    #[pyo3(get, set)]
+    pub expected_out: Option<HashMap<String, LazyLoadedTensor>>,
+}
+
+#[pymethods]
+impl SelfTest {
+    #[new]
+    fn new<'py>(
+        inputs: HashMap<String, SupportedTensorType<'py>>,
+        name: Option<String>,
+        description: Option<String>,
+        expected_out: Option<HashMap<String, SupportedTensorType<'py>>>,
+    ) -> PyResult<Self> {
+        Ok(Self {
+            name,
+            description,
+            inputs: convert_map(inputs),
+            expected_out: convert_opt_map(expected_out),
+        })
+    }
+}
+
+impl From<SelfTest> for carton_core::info::SelfTest<PyTensorStorage> {
+    fn from(value: SelfTest) -> Self {
+        Self {
+            name: value.name,
+            description: value.description,
+            inputs: convert_map(value.inputs),
+            expected_out: convert_opt_map(value.expected_out),
+        }
+    }
+}
+
+impl From<carton_core::info::SelfTest<carton_core::types::GenericStorage>> for SelfTest {
+    fn from(value: carton_core::info::SelfTest<carton_core::types::GenericStorage>) -> Self {
+        Self {
+            name: value.name,
+            description: value.description,
+            inputs: convert_map(value.inputs),
+            expected_out: convert_opt_map(value.expected_out),
+        }
+    }
+}
+
+#[derive(FromPyObject)]
+pub(crate) enum PyArrayOrMisc<'py> {
+    Tensor(SupportedTensorType<'py>),
+    Misc(Vec<u8>),
+}
+
+impl<'py> From<PyArrayOrMisc<'py>> for TensorOrMisc {
+    fn from(value: PyArrayOrMisc<'py>) -> Self {
+        match value {
+            PyArrayOrMisc::Tensor(v) => Self::Tensor(v.into()),
+            PyArrayOrMisc::Misc(v) => Self::Misc(v.into()),
+        }
+    }
+}
+
+#[pyclass]
+#[derive(Clone, Debug)]
+pub(crate) struct Example {
+    #[pyo3(get, set)]
+    pub name: Option<String>,
+
+    #[pyo3(get, set)]
+    pub description: Option<String>,
+
+    #[pyo3(get, set)]
+    pub inputs: HashMap<String, TensorOrMisc>,
+
+    #[pyo3(get, set)]
+    pub sample_out: HashMap<String, TensorOrMisc>,
+}
+
+#[pymethods]
+impl Example {
+    #[new]
+    fn new<'py>(
+        inputs: HashMap<String, PyArrayOrMisc<'py>>,
+        sample_out: HashMap<String, PyArrayOrMisc<'py>>,
+        name: Option<String>,
+        description: Option<String>,
+    ) -> PyResult<Self> {
+        Ok(Self {
+            name,
+            description,
+            inputs: convert_map(inputs),
+            sample_out: convert_map(sample_out),
+        })
+    }
+}
+
+impl From<Example> for carton_core::info::Example<PyTensorStorage> {
+    fn from(value: Example) -> Self {
+        Self {
+            name: value.name,
+            description: value.description,
+            inputs: convert_map(value.inputs),
+            sample_out: convert_map(value.sample_out),
+        }
+    }
+}
+
+impl From<carton_core::info::Example<GenericStorage>> for Example {
+    fn from(value: carton_core::info::Example<GenericStorage>) -> Self {
+        Self {
+            name: value.name,
+            description: value.description,
+            inputs: convert_map(value.inputs),
+            sample_out: convert_map(value.sample_out),
+        }
+    }
+}
+
+#[pyclass]
+#[derive(Clone)]
+pub(crate) struct LazyLoadedTensor {
+    inner: carton_core::info::PossiblyLoaded<Tensor<PyTensorStorage>>,
+}
+
+impl std::fmt::Debug for LazyLoadedTensor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LazyLoadedTensor").finish()
+    }
+}
+
+impl<'py> From<SupportedTensorType<'py>> for LazyLoadedTensor {
+    fn from(value: SupportedTensorType<'py>) -> Self {
+        LazyLoadedTensor {
+            inner: carton_core::info::PossiblyLoaded::from_value(value.into()),
+        }
+    }
+}
+
+#[pymethods]
+impl LazyLoadedTensor {
+    fn get<'a>(&self, py: Python<'a>) -> PyResult<&'a PyAny> {
+        let inner = self.inner.clone();
+        pyo3_asyncio::tokio::future_into_py(py, async move {
+            let t = inner.get().await;
+            Ok(tensor_to_py(t))
+        })
+    }
+}
+
+impl From<LazyLoadedTensor> for carton_core::info::PossiblyLoaded<Tensor<PyTensorStorage>> {
+    fn from(value: LazyLoadedTensor) -> Self {
+        value.inner
+    }
+}
+
+impl From<carton_core::info::PossiblyLoaded<carton_core::types::Tensor<GenericStorage>>>
+    for LazyLoadedTensor
+{
+    fn from(
+        value: carton_core::info::PossiblyLoaded<carton_core::types::Tensor<GenericStorage>>,
+    ) -> Self {
+        Self {
+            inner: carton_core::info::PossiblyLoaded::from_loader(Box::pin(async move {
+                let item = value.get().await;
+
+                // TODO: this makes a copy
+                Python::with_gil(|py| {
+                    match item {
+                        Tensor::Float(item) => Tensor::Float(item.view().to_pyarray(py).into()),
+                        Tensor::Double(item) => Tensor::Double(item.view().to_pyarray(py).into()),
+                        // Tensor::String(item) => item.view().to_pyarray(py).to_object(py),
+                        Tensor::String(_) => panic!("String tensor output not implemented yet"),
+                        Tensor::I8(item) => Tensor::I8(item.view().to_pyarray(py).into()),
+                        Tensor::I16(item) => Tensor::I16(item.view().to_pyarray(py).into()),
+                        Tensor::I32(item) => Tensor::I32(item.view().to_pyarray(py).into()),
+                        Tensor::I64(item) => Tensor::I64(item.view().to_pyarray(py).into()),
+                        Tensor::U8(item) => Tensor::U8(item.view().to_pyarray(py).into()),
+                        Tensor::U16(item) => Tensor::U16(item.view().to_pyarray(py).into()),
+                        Tensor::U32(item) => Tensor::U32(item.view().to_pyarray(py).into()),
+                        Tensor::U64(item) => Tensor::U64(item.view().to_pyarray(py).into()),
+                        Tensor::NestedTensor(_) => {
+                            panic!("Nested tensor output not implemented yet")
+                        }
+                    }
+                })
+            })),
+        }
+    }
+}
+
+#[pyclass]
+#[derive(Clone)]
+pub(crate) struct LazyLoadedMiscFile {
+    inner: Arc<LazyLoadedMiscFileInner>,
+}
+
+struct LazyLoadedMiscFileInner {
+    loader: carton_core::info::ArcMiscFileLoader,
+
+    // Once the file has been loaded
+    // TODO: see if we can avoid a mutex here
+    item: Mutex<Option<carton_core::info::MiscFile>>,
+}
+
+impl std::fmt::Debug for LazyLoadedMiscFile {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LazyLoadedMiscFile").finish()
+    }
+}
+
+/// An in memory misc file
+#[derive(Clone)]
+struct PyMiscFile(Arc<Vec<u8>>);
+
+impl AsRef<[u8]> for PyMiscFile {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+struct PyMiscFileLoader {
+    data: PyMiscFile,
+}
+
+#[async_trait]
+impl carton_core::info::MiscFileLoader for PyMiscFileLoader {
+    async fn get(&self) -> carton_core::info::MiscFile {
+        Box::new(std::io::Cursor::new(self.data.clone()))
+    }
+}
+
+impl From<Vec<u8>> for LazyLoadedMiscFile {
+    fn from(value: Vec<u8>) -> Self {
+        LazyLoadedMiscFile {
+            inner: Arc::new(LazyLoadedMiscFileInner {
+                loader: Arc::new(PyMiscFileLoader {
+                    data: PyMiscFile(Arc::new(value)),
+                }),
+                item: Mutex::new(None),
+            }),
+        }
+    }
+}
+
+#[pymethods]
+impl LazyLoadedMiscFile {
+    fn read<'a>(&self, py: Python<'a>, size_bytes: Option<u64>) -> PyResult<&'a PyAny> {
+        let inner = self.inner.clone();
+        pyo3_asyncio::tokio::future_into_py(py, async move {
+            // Actually load the file if we need to
+            let mut item = inner.item.lock().await;
+            if item.is_none() {
+                *item = Some(inner.loader.get().await);
+            }
+
+            if let Some(file) = item.as_mut() {
+                let buf = if let Some(size_bytes) = size_bytes {
+                    let mut buf = vec![0; size_bytes as usize];
+                    file.read_exact(&mut buf).await.unwrap();
+                    buf
+                } else {
+                    let mut buf = Vec::new();
+                    file.read_to_end(&mut buf).await.unwrap();
+                    buf
+                };
+
+                // TODO: this makes a copy
+                let out: PyObject = Python::with_gil(|py| PyBytes::new(py, &buf).into());
+                Ok(out)
+            } else {
+                panic!("Error when loading file from carton. Please file an issue.")
+            }
+        })
+    }
+}
+
+impl From<LazyLoadedMiscFile> for carton_core::info::ArcMiscFileLoader {
+    fn from(value: LazyLoadedMiscFile) -> Self {
+        value.inner.loader.clone()
+    }
+}
+
+impl From<carton_core::info::ArcMiscFileLoader> for LazyLoadedMiscFile {
+    fn from(value: carton_core::info::ArcMiscFileLoader) -> Self {
+        Self {
+            inner: Arc::new(LazyLoadedMiscFileInner {
+                loader: value,
+                item: Mutex::new(None),
+            }),
+        }
+    }
+}
+
+#[derive(Clone, FromPyObject, Debug)]
+pub(crate) enum TensorOrMisc {
+    Tensor(LazyLoadedTensor),
+    Misc(LazyLoadedMiscFile),
+}
+
+impl From<TensorOrMisc> for carton_core::info::TensorOrMisc<PyTensorStorage> {
+    fn from(value: TensorOrMisc) -> Self {
+        match value {
+            TensorOrMisc::Tensor(v) => Self::Tensor(v.into()),
+            TensorOrMisc::Misc(v) => Self::Misc(v.into()),
+        }
+    }
+}
+
+impl From<carton_core::info::TensorOrMisc<GenericStorage>> for TensorOrMisc {
+    fn from(value: carton_core::info::TensorOrMisc<GenericStorage>) -> Self {
+        match value {
+            carton_core::info::TensorOrMisc::Tensor(v) => Self::Tensor(v.into()),
+            carton_core::info::TensorOrMisc::Misc(v) => Self::Misc(v.into()),
+        }
+    }
+}
+
+impl IntoPy<PyObject> for TensorOrMisc {
+    fn into_py(self, py: Python<'_>) -> PyObject {
+        match self {
+            TensorOrMisc::Tensor(v) => v.into_py(py),
+            TensorOrMisc::Misc(v) => v.into_py(py),
+        }
+    }
+}
+
+#[pyclass]
+#[derive(Clone, Debug)]
+pub(crate) struct RunnerInfo {
+    /// The name of the runner to use
+    #[pyo3(get)]
+    pub runner_name: String,
+
+    /// The required framework version range to run the model with
+    /// This is a semver version range. See https://docs.rs/semver/1.0.16/semver/struct.VersionReq.html
+    /// for format details.
+    /// For example `=1.2.4`, means exactly version `1.2.4`
+    /// In most cases, this should be exactly one version
+    #[pyo3(get)]
+    pub required_framework_version: String,
+
+    /// Don't set this unless you know what you're doing
+    #[pyo3(get)]
+    pub runner_compat_version: Option<u64>,
+
+    /// Options to pass to the runner. These are runner-specific (e.g.
+    /// PyTorch, TensorFlow, etc).
+    ///
+    /// Sometimes used to configure thread-pool sizes, etc.
+    /// See the documentation for more info
+    #[pyo3(get)]
+    pub opts: Option<HashMap<String, PyRunnerOpt>>,
+}
+
+#[derive(FromPyObject, Clone, Debug)]
+pub(crate) enum PyRunnerOpt {
+    Integer(i64),
+    Double(f64),
+    String(String),
+    Boolean(bool),
+}
+
+impl From<PyRunnerOpt> for RunnerOpt {
+    fn from(value: PyRunnerOpt) -> Self {
+        match value {
+            PyRunnerOpt::Integer(v) => Self::Integer(v),
+            PyRunnerOpt::Double(v) => Self::Double(v),
+            PyRunnerOpt::String(v) => Self::String(v),
+            PyRunnerOpt::Boolean(v) => Self::Boolean(v),
+        }
+    }
+}
+
+impl From<RunnerOpt> for PyRunnerOpt {
+    fn from(value: RunnerOpt) -> Self {
+        match value {
+            RunnerOpt::Integer(v) => Self::Integer(v),
+            RunnerOpt::Double(v) => Self::Double(v),
+            RunnerOpt::String(v) => Self::String(v),
+            RunnerOpt::Boolean(v) => Self::Boolean(v),
+        }
+    }
+}
+
+impl IntoPy<PyObject> for PyRunnerOpt {
+    fn into_py(self, py: Python<'_>) -> PyObject {
+        match self {
+            PyRunnerOpt::Integer(v) => v.into_py(py),
+            PyRunnerOpt::Double(v) => v.into_py(py),
+            PyRunnerOpt::String(v) => v.into_py(py),
+            PyRunnerOpt::Boolean(v) => v.into_py(py),
+        }
+    }
+}

--- a/source/carton-bindings-py/src/lib.rs
+++ b/source/carton-bindings-py/src/lib.rs
@@ -1,116 +1,14 @@
-use std::{collections::HashMap, str::FromStr, sync::Arc};
+use std::{collections::HashMap, sync::Arc};
 
-use carton_core::{
-    info::RunnerInfo,
-    types::{
-        Device, GenericStorage, LoadOpts, PackOpts, RunnerOpt, Tensor, TensorStorage, TypedStorage,
-    },
+use conversions::{
+    create_load_opts, create_pack_opts, CartonInfo, Example, LazyLoadedMiscFile, LazyLoadedTensor,
+    PyRunnerOpt, RunnerInfo, SelfTest, TensorSpec,
 };
-use ndarray::ShapeBuilder;
-use numpy::{PyArrayDyn, ToPyArray};
 use pyo3::{exceptions::PyValueError, prelude::*, types::PyDict};
-use semver::VersionReq;
+use tensor::{tensor_to_py, SupportedTensorType};
 
-#[derive(FromPyObject)]
-enum SupportedTensorType<'py> {
-    Float(&'py PyArrayDyn<f32>),
-    Double(&'py PyArrayDyn<f64>),
-    // TODO: handle this
-    // String(&'py PyArrayDyn<PyString>),
-    I8(&'py PyArrayDyn<i8>),
-    I16(&'py PyArrayDyn<i16>),
-    I32(&'py PyArrayDyn<i32>),
-    I64(&'py PyArrayDyn<i64>),
-
-    U8(&'py PyArrayDyn<u8>),
-    U16(&'py PyArrayDyn<u16>),
-    U32(&'py PyArrayDyn<u32>),
-    U64(&'py PyArrayDyn<u64>),
-}
-
-struct PyTensorStorage {}
-
-impl TensorStorage for PyTensorStorage {
-    type TypedStorage<T> = TypedPyTensorStorage<T>
-    where
-        T: Send + Sync;
-}
-
-struct TypedPyTensorStorage<T> {
-    /// This keeps the data "alive" while this tensor is in scope
-    _keepalive: Py<PyArrayDyn<T>>,
-    shape: ndarray::StrideShape<ndarray::IxDyn>,
-    ptr: *mut T,
-}
-
-/// See the note in the `TypedStorage` impl below for why this is safe
-unsafe impl<T> Send for TypedPyTensorStorage<T> where T: Send {}
-unsafe impl<T> Sync for TypedPyTensorStorage<T> where T: Sync {}
-
-impl<T: numpy::Element> TypedPyTensorStorage<T> {
-    fn new(item: &PyArrayDyn<T>) -> Self {
-        // We don't want to hold the GIL in the methods in `TypedStorage<T>`. This means
-        // we can't do any operations on PyArrayDyn. Therefore, we extract the shape and
-        // pointer below. See the safety notes in the TypedStorage impl below.
-
-        let shape = item.shape().strides(
-            &item
-                .strides()
-                .into_iter()
-                .map(|s| (*s).try_into().unwrap())
-                .collect::<Vec<usize>>(),
-        );
-
-        let ptr = item.data();
-
-        Self {
-            _keepalive: item.into(),
-            shape,
-            ptr,
-        }
-    }
-}
-
-impl<T> TypedStorage<T> for TypedPyTensorStorage<T> {
-    fn view(&self) -> ndarray::ArrayViewD<T> {
-        // SAFETY: Because we hold Py<_> of the array in `_keepalive`, the array has not been
-        // reclaimed or deallocated by python.
-        // TODO: confirm that there isn't a way for the shape or data pointer to change
-        unsafe { ndarray::ArrayViewD::from_shape_ptr(self.shape.clone(), self.ptr) }
-    }
-
-    fn view_mut(&mut self) -> ndarray::ArrayViewMutD<T> {
-        // SAFETY: Because we hold Py<_> of the array in `_keepalive`, the array has not been
-        // reclaimed or deallocated by python.
-        // TODO: confirm that there isn't a way for the shape or data pointer to change
-        unsafe { ndarray::ArrayViewMutD::from_shape_ptr(self.shape.clone(), self.ptr as _) }
-    }
-}
-
-impl<T: numpy::Element> From<&PyArrayDyn<T>> for TypedPyTensorStorage<T> {
-    fn from(value: &PyArrayDyn<T>) -> Self {
-        Self::new(value)
-    }
-}
-
-impl From<SupportedTensorType<'_>> for Tensor<PyTensorStorage> {
-    fn from(value: SupportedTensorType<'_>) -> Self {
-        match value {
-            SupportedTensorType::Float(item) => Tensor::Float(item.into()),
-            SupportedTensorType::Double(item) => Tensor::Double(item.into()),
-
-            SupportedTensorType::I8(item) => Tensor::I8(item.into()),
-            SupportedTensorType::I16(item) => Tensor::I16(item.into()),
-            SupportedTensorType::I32(item) => Tensor::I32(item.into()),
-            SupportedTensorType::I64(item) => Tensor::I64(item.into()),
-
-            SupportedTensorType::U8(item) => Tensor::U8(item.into()),
-            SupportedTensorType::U16(item) => Tensor::U16(item.into()),
-            SupportedTensorType::U32(item) => Tensor::U32(item.into()),
-            SupportedTensorType::U64(item) => Tensor::U64(item.into()),
-        }
-    }
-}
+mod conversions;
+mod tensor;
 
 #[pyclass]
 #[derive(Clone)]
@@ -122,18 +20,25 @@ struct SealHandle {
 struct Carton {
     inner: Arc<carton_core::Carton>,
 }
-// TODO do we need with_gil?
 
 #[pymethods]
 impl Carton {
-    #[getter]
-    fn name(&self) -> PyResult<Option<&String>> {
-        Ok(self.inner.get_info().model_name.as_ref())
-    }
+    fn infer<'a>(&self, py: Python<'a>, tensors: &PyDict) -> PyResult<&'a PyAny> {
+        let tensors: HashMap<String, SupportedTensorType> = tensors.extract().unwrap();
+        let transformed = tensors.into_iter().map(|(k, v)| (k, v.into())).collect();
 
-    #[getter]
-    fn runner(&self) -> PyResult<&str> {
-        Ok(&self.inner.get_info().runner.runner_name)
+        let inner = self.inner.clone();
+        pyo3_asyncio::tokio::future_into_py(py, async move {
+            let out: HashMap<String, PyObject> = inner
+                .infer_with_inputs(transformed)
+                .await
+                .unwrap()
+                .into_iter()
+                .map(|(k, v)| (k, tensor_to_py(&v)))
+                .collect();
+
+            Ok(out)
+        })
     }
 
     fn seal<'a>(&self, py: Python<'a>, tensors: &PyDict) -> PyResult<&'a PyAny> {
@@ -147,125 +52,45 @@ impl Carton {
         })
     }
 
-    // TODO: merge the infer methods into one
-    fn infer_with_inputs<'a>(&self, py: Python<'a>, tensors: &PyDict) -> PyResult<&'a PyAny> {
-        let tensors: HashMap<String, SupportedTensorType> = tensors.extract().unwrap();
-        let transformed = tensors.into_iter().map(|(k, v)| (k, v.into())).collect();
-
-        let inner = self.inner.clone();
-        pyo3_asyncio::tokio::future_into_py(py, async move {
-            let out = inner.infer_with_inputs(transformed).await.unwrap();
-
-            let mut transformed: HashMap<String, PyObject> = HashMap::new();
-
-            for (k, v) in out {
-                // TODO this makes a copy
-                let pytype = Python::with_gil(|py| {
-                    match v {
-                        Tensor::Float(item) => item.view().to_pyarray(py).to_object(py),
-                        Tensor::Double(item) => item.view().to_pyarray(py).to_object(py),
-                        // Tensor::String(item) => item.view().to_pyarray(py).to_object(py),
-                        Tensor::String(_) => panic!("String tensor output not implemented yet"),
-                        Tensor::I8(item) => item.view().to_pyarray(py).to_object(py),
-                        Tensor::I16(item) => item.view().to_pyarray(py).to_object(py),
-                        Tensor::I32(item) => item.view().to_pyarray(py).to_object(py),
-                        Tensor::I64(item) => item.view().to_pyarray(py).to_object(py),
-                        Tensor::U8(item) => item.view().to_pyarray(py).to_object(py),
-                        Tensor::U16(item) => item.view().to_pyarray(py).to_object(py),
-                        Tensor::U32(item) => item.view().to_pyarray(py).to_object(py),
-                        Tensor::U64(item) => item.view().to_pyarray(py).to_object(py),
-                        Tensor::NestedTensor(_) => {
-                            panic!("Nested tensor output not implemented yet")
-                        }
-                    }
-                });
-
-                transformed.insert(k, pytype);
-            }
-
-            Ok(transformed)
-        })
-    }
-
-    // TODO: merge the infer methods into one
     fn infer_with_handle<'a>(&self, py: Python<'a>, handle: SealHandle) -> PyResult<&'a PyAny> {
         let inner = self.inner.clone();
         pyo3_asyncio::tokio::future_into_py(py, async move {
-            let out = inner.infer_with_handle(handle.inner).await.unwrap();
+            let out: HashMap<String, PyObject> = inner
+                .infer_with_handle(handle.inner)
+                .await
+                .unwrap()
+                .into_iter()
+                .map(|(k, v)| (k, tensor_to_py(&v)))
+                .collect();
 
-            let mut transformed: HashMap<String, PyObject> = HashMap::new();
-
-            for (k, v) in out {
-                // TODO this makes a copy
-                let pytype = Python::with_gil(|py| {
-                    match v {
-                        Tensor::Float(item) => item.view().to_pyarray(py).to_object(py),
-                        Tensor::Double(item) => item.view().to_pyarray(py).to_object(py),
-                        // Tensor::String(item) => item.view().to_pyarray(py).to_object(py),
-                        Tensor::String(_) => panic!("String tensor output not implemented yet"),
-                        Tensor::I8(item) => item.view().to_pyarray(py).to_object(py),
-                        Tensor::I16(item) => item.view().to_pyarray(py).to_object(py),
-                        Tensor::I32(item) => item.view().to_pyarray(py).to_object(py),
-                        Tensor::I64(item) => item.view().to_pyarray(py).to_object(py),
-                        Tensor::U8(item) => item.view().to_pyarray(py).to_object(py),
-                        Tensor::U16(item) => item.view().to_pyarray(py).to_object(py),
-                        Tensor::U32(item) => item.view().to_pyarray(py).to_object(py),
-                        Tensor::U64(item) => item.view().to_pyarray(py).to_object(py),
-                        Tensor::NestedTensor(_) => {
-                            panic!("Nested tensor output not implemented yet")
-                        }
-                    }
-                });
-
-                transformed.insert(k, pytype);
-            }
-
-            Ok(transformed)
+            Ok(out)
         })
     }
-}
 
-#[derive(FromPyObject)]
-enum PyRunnerOpt {
-    Integer(i64),
-    Double(f64),
-    String(String),
-    Boolean(bool),
-    // TODO: datetime
-    // Date(DateTime<Utc>),
-}
-
-impl From<PyRunnerOpt> for RunnerOpt {
-    fn from(value: PyRunnerOpt) -> Self {
-        match value {
-            PyRunnerOpt::Integer(v) => Self::Integer(v),
-            PyRunnerOpt::Double(v) => Self::Double(v),
-            PyRunnerOpt::String(v) => Self::String(v),
-            PyRunnerOpt::Boolean(v) => Self::Boolean(v),
-        }
+    #[getter]
+    fn info(&self) -> CartonInfo {
+        // TODO: maybe cache this conversion?
+        (*self.inner.get_info()).clone().into()
     }
 }
 
-/// Loads a model
+/// Load a model
 #[pyfunction]
 fn load(
     py: Python,
     path: String,
+    visible_device: Option<String>,
     override_runner_name: Option<String>,
     override_required_framework_version: Option<String>,
     override_runner_opts: Option<HashMap<String, PyRunnerOpt>>,
-    visible_device: String,
 ) -> PyResult<&PyAny> {
     pyo3_asyncio::tokio::future_into_py(py, async move {
-        let opts = LoadOpts {
+        let opts = create_load_opts(
+            visible_device,
             override_runner_name,
             override_required_framework_version,
-            override_runner_opts: override_runner_opts
-                .map(|opts| opts.into_iter().map(|(k, v)| (k, v.into())).collect()),
-            // TODO: use something more specific than ValueError
-            visible_device: Device::maybe_from_str(&visible_device)
-                .map_err(|e| PyValueError::new_err(e.to_string()))?,
-        };
+            override_runner_opts,
+        )?;
 
         // TODO: use something more specific than ValueError
         let inner = carton_core::Carton::load(path, opts)
@@ -278,43 +103,45 @@ fn load(
 }
 
 /// Load an unpacked model
+/// Has all the options of `pack` and the non-override options of `load`
 #[pyfunction]
 fn load_unpacked(
     py: Python,
     path: String,
     runner_name: String,
     required_framework_version: String,
-    opts: Option<HashMap<String, PyRunnerOpt>>,
-    visible_device: String,
+    runner_compat_version: Option<u64>,
+    runner_opts: Option<HashMap<String, PyRunnerOpt>>,
+    model_name: Option<String>,
+    short_description: Option<String>,
+    model_description: Option<String>,
+    required_platforms: Option<Vec<String>>,
+    inputs: Option<Vec<TensorSpec>>,
+    outputs: Option<Vec<TensorSpec>>,
+    self_tests: Option<Vec<SelfTest>>,
+    examples: Option<Vec<Example>>,
+    misc_files: Option<HashMap<String, Vec<u8>>>,
+    visible_device: Option<String>,
 ) -> PyResult<&PyAny> {
     pyo3_asyncio::tokio::future_into_py(py, async move {
-        let pack_opts = PackOpts::<GenericStorage> {
-            model_name: None,
-            short_description: None,
-            model_description: None,
-            required_platforms: None,
-            inputs: None,
-            outputs: None,
-            self_tests: None,
-            examples: None,
-            runner: RunnerInfo {
-                runner_name,
-                required_framework_version: VersionReq::from_str(&required_framework_version)
-                    .map_err(|e| {
-                        PyValueError::new_err(format!("Invalid `required_framework_version`: {e}"))
-                    })?,
-                runner_compat_version: None,
-                opts: opts.map(|opts| opts.into_iter().map(|(k, v)| (k, v.into())).collect()),
-            },
-            misc_files: None,
-        };
+        let pack_opts = create_pack_opts(
+            runner_name,
+            required_framework_version,
+            runner_compat_version,
+            runner_opts,
+            model_name,
+            short_description,
+            model_description,
+            required_platforms,
+            inputs,
+            outputs,
+            self_tests,
+            examples,
+            misc_files,
+        )?;
 
-        // TODO: use something more specific than ValueError
-        let load_opts = LoadOpts {
-            visible_device: Device::maybe_from_str(&visible_device)
-                .map_err(|e| PyValueError::new_err(e.to_string()))?,
-            ..Default::default()
-        };
+        // No need for overrides here
+        let load_opts = create_load_opts(visible_device, None, None, None)?;
 
         let inner = carton_core::Carton::load_unpacked(path, pack_opts, load_opts)
             .await
@@ -326,13 +153,79 @@ fn load_unpacked(
     })
 }
 
+/// Pack a model
+#[pyfunction]
+fn pack(
+    py: Python,
+    path: String,
+    runner_name: String,
+    required_framework_version: String,
+    runner_compat_version: Option<u64>,
+    runner_opts: Option<HashMap<String, PyRunnerOpt>>,
+    model_name: Option<String>,
+    short_description: Option<String>,
+    model_description: Option<String>,
+    required_platforms: Option<Vec<String>>,
+    inputs: Option<Vec<TensorSpec>>,
+    outputs: Option<Vec<TensorSpec>>,
+    self_tests: Option<Vec<SelfTest>>,
+    examples: Option<Vec<Example>>,
+    misc_files: Option<HashMap<String, Vec<u8>>>,
+) -> PyResult<&PyAny> {
+    pyo3_asyncio::tokio::future_into_py(py, async move {
+        let opts = create_pack_opts(
+            runner_name,
+            required_framework_version,
+            runner_compat_version,
+            runner_opts,
+            model_name,
+            short_description,
+            model_description,
+            required_platforms,
+            inputs,
+            outputs,
+            self_tests,
+            examples,
+            misc_files,
+        )?;
+
+        let out = carton_core::Carton::pack(path, opts)
+            .await
+            .map_err(|e| PyValueError::new_err(e.to_string()))?;
+
+        Ok(out)
+    })
+}
+
+/// Get info for a model
+#[pyfunction]
+fn get_model_info(py: Python, url_or_path: String) -> PyResult<&PyAny> {
+    pyo3_asyncio::tokio::future_into_py(py, async move {
+        let out: CartonInfo = carton_core::Carton::get_model_info(url_or_path)
+            .await
+            .map_err(|e| PyValueError::new_err(e.to_string()))?
+            .into();
+
+        Ok(out)
+    })
+}
+
 /// A Python module implemented in Rust. The name of this function must match
 /// the `lib.name` setting in the `Cargo.toml`, else Python will not be able to
 /// import the module.
 #[pymodule]
 fn cartonml(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(load, m)?)?;
+    m.add_function(wrap_pyfunction!(pack, m)?)?;
     m.add_function(wrap_pyfunction!(load_unpacked, m)?)?;
+    m.add_function(wrap_pyfunction!(get_model_info, m)?)?;
     m.add_class::<Carton>()?;
+    m.add_class::<CartonInfo>()?;
+    m.add_class::<TensorSpec>()?;
+    m.add_class::<SelfTest>()?;
+    m.add_class::<Example>()?;
+    m.add_class::<LazyLoadedTensor>()?;
+    m.add_class::<LazyLoadedMiscFile>()?;
+    m.add_class::<RunnerInfo>()?;
     Ok(())
 }

--- a/source/carton-bindings-py/src/tensor.rs
+++ b/source/carton-bindings-py/src/tensor.rs
@@ -1,0 +1,142 @@
+use carton_core::types::{Tensor, TensorStorage, TypedStorage};
+use ndarray::ShapeBuilder;
+use numpy::{PyArrayDyn, ToPyArray};
+use pyo3::{FromPyObject, Py, PyObject, Python, ToPyObject};
+
+#[derive(FromPyObject)]
+pub(crate) enum SupportedTensorType<'py> {
+    Float(&'py PyArrayDyn<f32>),
+    Double(&'py PyArrayDyn<f64>),
+    // TODO: handle this
+    // String(&'py PyArrayDyn<PyString>),
+    I8(&'py PyArrayDyn<i8>),
+    I16(&'py PyArrayDyn<i16>),
+    I32(&'py PyArrayDyn<i32>),
+    I64(&'py PyArrayDyn<i64>),
+
+    U8(&'py PyArrayDyn<u8>),
+    U16(&'py PyArrayDyn<u16>),
+    U32(&'py PyArrayDyn<u32>),
+    U64(&'py PyArrayDyn<u64>),
+}
+
+pub(crate) struct PyTensorStorage {}
+
+impl TensorStorage for PyTensorStorage {
+    type TypedStorage<T> = TypedPyTensorStorage<T>
+    where
+        T: Send + Sync;
+}
+
+pub(crate) struct TypedPyTensorStorage<T> {
+    /// This keeps the data "alive" while this tensor is in scope
+    _keepalive: Py<PyArrayDyn<T>>,
+    ptr: *const T,
+    shape: Vec<usize>,
+    strides: Vec<usize>,
+}
+
+/// See the note in the `TypedStorage` impl below for why this is safe
+unsafe impl<T> Send for TypedPyTensorStorage<T> where T: Send {}
+unsafe impl<T> Sync for TypedPyTensorStorage<T> where T: Sync {}
+
+impl<T: numpy::Element + std::fmt::Debug> TypedPyTensorStorage<T> {
+    fn new(item: &PyArrayDyn<T>) -> Self {
+        // We don't want to hold the GIL in the methods in `TypedStorage<T>`. This means
+        // we can't do any operations on PyArrayDyn. Therefore, we extract the shape and
+        // pointer below. See the safety notes in the TypedStorage impl below.
+
+        let view = unsafe { item.as_array() };
+        let ptr = view.as_ptr();
+        let shape = view.shape();
+        let strides = view.strides();
+
+        for item in strides {
+            if item < &0 {
+                // TODO: don't panic; return an error
+                panic!("Invalid strides when wrapping numpy array: {item}");
+            }
+        }
+
+        Self {
+            _keepalive: item.into(),
+            ptr,
+            shape: shape.into(),
+            strides: strides.into_iter().map(|item| *item as usize).collect(),
+        }
+    }
+}
+
+impl<T> TypedStorage<T> for TypedPyTensorStorage<T> {
+    fn view(&self) -> ndarray::ArrayViewD<T> {
+        // SAFETY: Because we hold Py<_> of the array in `_keepalive`, the array has not been
+        // reclaimed or deallocated by python.
+        // TODO: confirm that there isn't a way for the shape or data pointer to change
+        unsafe {
+            ndarray::ArrayViewD::from_shape_ptr(
+                self.shape.clone().strides(self.strides.clone()),
+                self.ptr,
+            )
+        }
+    }
+
+    fn view_mut(&mut self) -> ndarray::ArrayViewMutD<T> {
+        // SAFETY: Because we hold Py<_> of the array in `_keepalive`, the array has not been
+        // reclaimed or deallocated by python.
+        // TODO: confirm that there isn't a way for the shape or data pointer to change
+        unsafe {
+            ndarray::ArrayViewMutD::from_shape_ptr(
+                self.shape.clone().strides(self.strides.clone()),
+                self.ptr as _,
+            )
+        }
+    }
+}
+
+impl<T: numpy::Element + std::fmt::Debug> From<&PyArrayDyn<T>> for TypedPyTensorStorage<T> {
+    fn from(value: &PyArrayDyn<T>) -> Self {
+        Self::new(value)
+    }
+}
+
+impl From<SupportedTensorType<'_>> for Tensor<PyTensorStorage> {
+    fn from(value: SupportedTensorType<'_>) -> Self {
+        match value {
+            SupportedTensorType::Float(item) => Tensor::Float(item.into()),
+            SupportedTensorType::Double(item) => Tensor::Double(item.into()),
+
+            SupportedTensorType::I8(item) => Tensor::I8(item.into()),
+            SupportedTensorType::I16(item) => Tensor::I16(item.into()),
+            SupportedTensorType::I32(item) => Tensor::I32(item.into()),
+            SupportedTensorType::I64(item) => Tensor::I64(item.into()),
+
+            SupportedTensorType::U8(item) => Tensor::U8(item.into()),
+            SupportedTensorType::U16(item) => Tensor::U16(item.into()),
+            SupportedTensorType::U32(item) => Tensor::U32(item.into()),
+            SupportedTensorType::U64(item) => Tensor::U64(item.into()),
+        }
+    }
+}
+
+pub(crate) fn tensor_to_py<T: TensorStorage>(item: &Tensor<T>) -> PyObject {
+    // TODO this makes a copy
+    Python::with_gil(|py| {
+        match item {
+            Tensor::Float(item) => item.view().to_pyarray(py).to_object(py),
+            Tensor::Double(item) => item.view().to_pyarray(py).to_object(py),
+            // Tensor::String(item) => item.view().to_pyarray(py).to_object(py),
+            Tensor::String(_) => panic!("String tensor output not implemented yet"),
+            Tensor::I8(item) => item.view().to_pyarray(py).to_object(py),
+            Tensor::I16(item) => item.view().to_pyarray(py).to_object(py),
+            Tensor::I32(item) => item.view().to_pyarray(py).to_object(py),
+            Tensor::I64(item) => item.view().to_pyarray(py).to_object(py),
+            Tensor::U8(item) => item.view().to_pyarray(py).to_object(py),
+            Tensor::U16(item) => item.view().to_pyarray(py).to_object(py),
+            Tensor::U32(item) => item.view().to_pyarray(py).to_object(py),
+            Tensor::U64(item) => item.view().to_pyarray(py).to_object(py),
+            Tensor::NestedTensor(_) => {
+                panic!("Nested tensor output not implemented yet")
+            }
+        }
+    })
+}

--- a/source/carton-bindings-py/tests/test_load_unpacked.py
+++ b/source/carton-bindings-py/tests/test_load_unpacked.py
@@ -1,17 +1,139 @@
-import asyncio
+import unittest
 import cartonml as carton
+import numpy as np
+import urllib.request
+
+from cartonml import TensorSpec, SelfTest, Example
 import tempfile
 
-async def test():
-    """
-    Basic test of load_unpacked
-    """
-    dir = tempfile.mkdtemp()
-    with open(f'{dir}/requirements.txt', 'w') as f:
-        f.write("numpy")
+MODEL_DESCRIPTION = """
+Some description of the model that can be as detailed as you want it to be
 
-    with open(f'{dir}/main.py', 'w') as f:
-        f.write("""
+This can span multiple lines. It can use markdown, but shouldn't use arbitrary HTML
+(which will usually be treated as text instead of HTML when this is rendered)
+
+You can use images and links, but the paths must either be complete https
+URLs (e.g. https://example.com/image.png) or must reference a file in the misc folder (e.g `@misc/file.png`).
+See the `misc_files` section of this document for more details
+
+![Model Architecture](@misc/model_architecture.png)
+"""
+
+class Test(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        # Grab an image from the Penn-Fudan pedestrian detection database
+        with urllib.request.urlopen('https://www.cis.upenn.edu/~jshi/ped_html/images/PennPed00015_1.png') as f:
+            self.input_image = f.read()
+
+        # Grab the whisper approach graphic
+        with urllib.request.urlopen('https://raw.githubusercontent.com/openai/whisper/main/approach.png') as f:
+            self.model_architecture = f.read()
+
+    def test_roundtrip_tensorspec(self):
+        """
+        Ensure that python -> rust -> python doesn't change anything for TensorSpecs
+        """
+        items = [
+            dict(name = "a", dtype = "float32", shape = None),
+            dict(name = "b", dtype = "float64", shape = "some_symbol"),
+            dict(name = "c", dtype = "string", shape = [None]),
+            dict(name = "d", dtype = "int8", shape = ["some_symbol"]),
+            dict(name = "e", dtype = "int16", shape = []),
+            dict(name = "f", dtype = "int32", shape = ["batch_size", 3, 512, 512]),
+            dict(name = "g", dtype = "int64", shape = [None, None, None]),
+            dict(name = "h", dtype = "uint8", shape = [2, 3, 512, 512]),
+            dict(name = "i", dtype = "uint16", shape = ["multiple", "symbols"]),
+            dict(name = "j", dtype = "uint32", shape = [2, None, "symbol"]),
+            dict(name = "long", dtype = "uint64", shape = None, description = "A description"),
+        ]
+        
+        for item in items:
+            ts = TensorSpec(**item)
+
+            self.assertEqual(ts.name, item["name"])
+            self.assertEqual(ts.dtype, item["dtype"])
+            self.assertEqual(ts.shape, item["shape"])
+            if "description" in item:
+                self.assertEqual(ts.description, item["description"])
+
+    async def test_roundtrip_selftest(self):
+        """
+        Ensure that python -> rust -> python doesn't change anything for SelfTests
+        """
+        items = [
+            dict(
+                name = "a_self_test",
+                description = "A self test",
+                inputs = dict(a = np.ones(5, dtype=np.float32)),
+                expected_out = dict(y = np.ones(5, dtype=np.uint32))
+            ),
+            dict(
+                name = "2 ",
+                inputs = dict(a = np.random.rand(5)),
+                expected_out = dict(y = np.random.randint(1, 5, 5, dtype=np.uint32))
+            )
+        ]
+
+        for item in items:
+            st = SelfTest(**item)
+            self.assertEqual(st.name, item["name"])
+
+            for k, v in item["inputs"].items():
+                np.testing.assert_equal(await st.inputs[k].get(), v)
+
+            for k, v in item["expected_out"].items():
+                np.testing.assert_equal(await st.expected_out[k].get(), v)
+
+            if "description" in item:
+                self.assertEqual(st.description, item["description"])
+
+    async def test_roundtrip_example(self):
+        """
+        Ensure that python -> rust -> python doesn't change anything for Examples
+        """
+        items = [
+            dict(
+                name = "an_optional_name",
+                description = "An example of an image input",
+                inputs = dict(f = self.input_image),
+                sample_out = dict(y = np.array(5))
+            ),
+            dict(
+                name = " s o me na me wi th spaces",
+                inputs = dict(f = np.array(5)),
+                sample_out = dict(y = self.model_architecture, z = np.random.rand(5))
+            ),
+        ]
+
+        for item in items:
+            ex = Example(**item)
+            self.assertEqual(ex.name, item["name"])
+
+            for k, v in item["inputs"].items():
+                if isinstance(v, np.ndarray):
+                    np.testing.assert_equal(await ex.inputs[k].get(), v)
+                else:
+                    self.assertEqual(v, await ex.inputs[k].read())
+
+            for k, v in item["sample_out"].items():
+                if isinstance(v, np.ndarray):
+                    np.testing.assert_equal(await ex.sample_out[k].get(), v)
+                else:
+                    self.assertEqual(v, await ex.sample_out[k].read())
+
+            if "description" in item:
+                self.assertEqual(ex.description, item["description"])
+
+    async def test_load_unpacked(self):
+        """
+        Test of load_unpacked that uses most (if not all) of the documented arguments
+        """
+        dir = tempfile.mkdtemp()
+        with open(f'{dir}/requirements.txt', 'w') as f:
+            f.write("numpy")
+
+        with open(f'{dir}/main.py', 'w') as f:
+            f.write("""
 import sys
 import numpy as np
 
@@ -28,16 +150,106 @@ def get_model():
     return Model()
         """)
 
-    model = await carton.load_unpacked(dir, runner_name = "python", required_framework_version = "=3.11", opts = {
-        "entrypoint_package": "main",
-        "entrypoint_fn": "get_model",
-    }, visible_device = "CPU")
+        model = await carton.load_unpacked(
+            dir,
+            runner_name = "python",
+            required_framework_version = "=3.11",
+            runner_opts = {
+                "entrypoint_package": "main",
+                "entrypoint_fn": "get_model",
+            },
+            model_name = "Test Model",
+            short_description = "A short description that should be less than or equal to 100 characters.",
+            model_description = MODEL_DESCRIPTION,
+            required_platforms = [
+                "x86_64-unknown-linux-gnu",
+                "aarch64-unknown-linux-gnu",
+                "x86_64-apple-darwin",
+                "aarch64-apple-darwin",
+            ],
+            inputs = [
+                TensorSpec(
+                    name = "a",
+                    dtype = "float32",
+                    shape = None,
+                ),
+                TensorSpec(
+                    name = "b",
+                    dtype = "float64",
+                    shape = "some_symbol",
+                ),
+                TensorSpec(
+                    name = "c",
+                    dtype = "string",
+                    shape = [None],
+                ),
+                TensorSpec(
+                    name = "d",
+                    dtype = "int8",
+                    shape = ["some_symbol"],
+                ),
+                TensorSpec(
+                    name = "e",
+                    dtype = "int16",
+                    shape = [],
+                ),
+                TensorSpec(
+                    name = "f",
+                    dtype = "int32",
+                    shape = ["batch_size", 3, 512, 512],
+                ),
+                TensorSpec(
+                    name = "g",
+                    dtype = "int64",
+                    shape = [None, None, None],
+                ),
+            ],
+            outputs = [
+                TensorSpec(
+                    name = "y",
+                    dtype = "uint32",
+                    shape = [2, 3, 512, 512],
+                    description = "Some description of the output"
+                )
+            ],
+            self_tests = [
+                SelfTest(
+                    name = "a_self_test",
+                    description = "A self test",
+                    inputs = dict(a = np.ones(5, dtype=np.float32)),
+                    expected_out = dict(y = np.ones(5, dtype=np.uint32))
+                )
+            ],
+            examples = [
+                Example(
+                    name = "an_optional_name",
+                    description = "An example of an image input",
+                    inputs = dict(f = self.input_image),
+                    sample_out = dict(y = np.array(5))
+                )
+            ],
+            misc_files = {
+                "model_architecture.png": self.model_architecture
+            },
+            visible_device = "CPU"
+        )
 
-    out = await model.infer_with_inputs({})
+        out = await model.infer({})
 
-    major, minor = out["out"]
-    if major != 3 or minor != 11:
-        raise ValueError(f"Got an unexpected version of python. Got {major}.{minor} and expected 3.11")
+        major, minor = out["out"]
+        if major != 3 or minor != 11:
+            raise ValueError(f"Got an unexpected version of python. Got {major}.{minor} and expected 3.11")
+        
+        # Extract the example image from the model
+        example_image = await model.info.examples[0].inputs["f"].read()
+        self.assertEqual(self.input_image, example_image)
 
+        self_test_out = await model.info.self_tests[0].expected_out["y"].get()
+        np.testing.assert_equal(np.ones(5, dtype=np.uint32), self_test_out)
 
-asyncio.run(test())
+        # Extract the model architecture image
+        model_arch_readback = await model.info.misc_files["model_architecture.png"].read()
+        self.assertEqual(self.model_architecture, model_arch_readback)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/source/carton-runner-py/Cargo.toml
+++ b/source/carton-runner-py/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2021"
 carton-runner-interface = { path = "../carton-runner-interface" }
 carton-utils = { path = "../carton-utils" }
 tokio = { version = "1", features = ["full"] }
-pyo3 = { version = "0.17.3"}
-pyo3-asyncio = { version = "0.17", features = ["attributes", "tokio-runtime"] }
-numpy = "0.17"
+pyo3 = { version = "0.18"}
+pyo3-asyncio = { version = "0.18", features = ["attributes", "tokio-runtime"] }
+numpy = "0.18"
 ndarray = { version = "0.15" }
 lazy_static = "1.4.0"
 reqwest = { version = "0.11", features = ["native-tls-vendored"] }

--- a/source/carton/src/conversion_utils.rs
+++ b/source/carton/src/conversion_utils.rs
@@ -1,30 +1,30 @@
 //! Utilities to convert between (Vec<T> -> Vec<U>) and (HashMap<_, T> -> HashMap<_, U>)
 //! because `From` is not implemented for these types
 
-use std::{collections::HashMap, hash::Hash, marker::PhantomData};
+use std::{collections::HashMap, hash::Hash};
 
-pub(crate) fn convert_vec<T, U>(v: Vec<T>) -> Vec<U>
+pub fn convert_vec<T, U>(v: Vec<T>) -> Vec<U>
 where
     U: From<T>,
 {
     v.into_iter().map(|v| v.into()).collect()
 }
 
-pub(crate) fn convert_map<A: Hash + Eq, T, U>(v: HashMap<A, T>) -> HashMap<A, U>
+pub fn convert_map<A: Hash + Eq, T, U>(v: HashMap<A, T>) -> HashMap<A, U>
 where
     U: From<T>,
 {
     v.into_iter().map(|(k, v)| (k, v.into())).collect()
 }
 
-pub(crate) fn convert_opt_vec<T, U>(v: Option<Vec<T>>) -> Option<Vec<U>>
+pub fn convert_opt_vec<T, U>(v: Option<Vec<T>>) -> Option<Vec<U>>
 where
     U: From<T>,
 {
     v.map(|item| convert_vec(item))
 }
 
-pub(crate) fn convert_opt_map<A: Hash + Eq, T, U>(v: Option<HashMap<A, T>>) -> Option<HashMap<A, U>>
+pub fn convert_opt_map<A: Hash + Eq, T, U>(v: Option<HashMap<A, T>>) -> Option<HashMap<A, U>>
 where
     U: From<T>,
 {

--- a/source/carton/src/lib.rs
+++ b/source/carton/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod carton;
-mod conversion_utils;
+pub mod conversion_utils;
 pub mod error;
 mod format;
 mod http;


### PR DESCRIPTION
Implement conversions between the core Carton types and the types in the python bindings.

This PR also tests several of those type conversions (python -> rust -> python)