### PR TITLE
Extract Python string tensor utils into a separate crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,6 +366,7 @@ version = "0.0.1"
 dependencies = [
  "async-trait",
  "carton",
+ "carton-utils-py",
  "ndarray",
  "numpy",
  "pyo3",
@@ -373,7 +374,6 @@ dependencies = [
  "semver 1.0.16",
  "target-lexicon",
  "tokio",
- "widestring",
 ]
 
 [[package]]
@@ -460,6 +460,7 @@ dependencies = [
  "carton-runner-interface",
  "carton-runner-packager",
  "carton-utils",
+ "carton-utils-py",
  "clap 4.1.1",
  "escargot",
  "findshlibs",
@@ -506,6 +507,16 @@ dependencies = [
  "thiserror",
  "tokio",
  "toml",
+]
+
+[[package]]
+name = "carton-utils-py"
+version = "0.0.1"
+dependencies = [
+ "ndarray",
+ "numpy",
+ "pyo3",
+ "widestring",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,6 @@ members = [
     "source/carton-macros",
     "source/carton-runner-noop",
     "source/carton-runner-py",
+    "source/carton-utils-py",
     "source/anywhere",
 ]

--- a/source/carton-bindings-py/Cargo.toml
+++ b/source/carton-bindings-py/Cargo.toml
@@ -17,4 +17,4 @@ semver = {version = "1.0.16"}
 target-lexicon = "0.12.5"
 tokio = { version = "1", features = ["io-util"] }
 async-trait = "0.1"
-widestring = "1.0.2"
+carton-utils-py = {path = "../carton-utils-py"}

--- a/source/carton-bindings-py/src/tensor.rs
+++ b/source/carton-bindings-py/src/tensor.rs
@@ -1,10 +1,8 @@
 use carton_core::types::{Tensor, TensorStorage, TypedStorage};
+use carton_utils_py::tensor::PyStringArrayType;
 use ndarray::ShapeBuilder;
 use numpy::{PyArrayDyn, ToPyArray};
-use pyo3::{
-    types::PyTuple, AsPyPointer, FromPyObject, Py, PyAny, PyDowncastError, PyObject, Python,
-    ToPyObject,
-};
+use pyo3::{FromPyObject, Py, PyObject, Python, ToPyObject};
 
 #[derive(FromPyObject)]
 pub(crate) enum SupportedTensorType<'py> {
@@ -20,23 +18,7 @@ pub(crate) enum SupportedTensorType<'py> {
     U32(&'py PyArrayDyn<u32>),
     U64(&'py PyArrayDyn<u64>),
 
-    String(SomeArrayType<'py>),
-}
-
-pub(crate) struct SomeArrayType<'a> {
-    inner: &'a PyAny,
-}
-
-impl<'py> FromPyObject<'py> for SomeArrayType<'py> {
-    fn extract(ob: &'py PyAny) -> pyo3::PyResult<Self> {
-        unsafe {
-            if numpy::npyffi::PyArray_Check(ob.py(), ob.as_ptr()) == 0 {
-                return Err(PyDowncastError::new(ob, "SomeNumpyArray").into());
-            }
-        }
-
-        Ok(SomeArrayType { inner: ob })
-    }
+    String(PyStringArrayType<'py>),
 }
 
 pub(crate) struct PyTensorStorage {}
@@ -146,69 +128,8 @@ impl From<SupportedTensorType<'_>> for Tensor<PyTensorStorage> {
             SupportedTensorType::Float(item) => Tensor::Float(item.into()),
             SupportedTensorType::Double(item) => Tensor::Double(item.into()),
             SupportedTensorType::String(item) => {
-                let item = item.inner;
-
-                // Strings are a bit complex and require conversion
-                // This is unfortunate but necessary because most frameworks have different internal representations of strings
-                let kind: char = item
-                    .getattr("dtype")
-                    .unwrap()
-                    .getattr("kind")
-                    .unwrap()
-                    .extract()
-                    .unwrap();
-                let itemsize: usize = item.getattr("itemsize").unwrap().extract().unwrap();
-                if kind != 'U' {
-                    panic!(
-                        "We currently only support unicode strings. Got unsupported kind: {kind}"
-                    )
-                }
-
-                // Each utf32 char is 4 bytes
-                let num_chars_per_item = itemsize / 4;
-
-                let target_shape: Vec<usize> = item.getattr("shape").unwrap().extract().unwrap();
-
-                let item = if target_shape.is_empty() {
-                    // Make scalars into 1d arrays
-                    item.call_method1("reshape", (1,)).unwrap()
-                } else {
-                    item
-                };
-
-                // View as uint32
-                let view = item.call_method1("view", ("uint32",)).unwrap();
-
-                // Convert to np array
-                let view: &PyArrayDyn<u32> = view.extract().unwrap();
-
-                // TODO: handle not contiguous
-                let data = unsafe { view.as_slice().unwrap() };
-
-                // For each elem
-                let data = data
-                    .chunks(num_chars_per_item)
-                    .map(|item| {
-                        let iter = item
-                            .iter()
-                            // Reverse and remove trailing zeros
-                            .rev()
-                            .skip_while(|item| **item == 0);
-
-                        // Convert to codepoints
-                        let chars: Vec<char> = widestring::decode_utf32(iter.copied())
-                            .map(|v| v.unwrap())
-                            .collect();
-
-                        // Reverse again and collect into a string
-                        chars.into_iter().rev().collect()
-                    })
-                    .collect();
-
-                let arr = ndarray::ArrayD::from_shape_vec(target_shape, data).unwrap();
-
+                let arr = item.to_ndarray();
                 let out = StringPyTensorStorage::new(arr);
-
                 Tensor::String(out)
             }
 
@@ -235,46 +156,7 @@ pub(crate) fn tensor_to_py<T: TensorStorage>(item: &Tensor<T>) -> PyObject {
                 // Strings are a bit more complex and require conversion
                 // This is unfortunate but necessary because most frameworks have different internal representations of strings
                 let view = item.view();
-
-                // First, convert to utf-32
-                let strings: Vec<Vec<u32>> = view
-                    .iter()
-                    .map(|item| widestring::encode_utf32(item.chars()).collect())
-                    .collect();
-
-                // Find the length of the longest one
-                // TODO: handle empty string arrays
-                let longest_string_len_chars = strings.iter().map(|v| v.len()).max().unwrap();
-
-                // Create a u32 array
-                let output = numpy::PyArray::<u32, _>::zeros(
-                    py,
-                    (strings.len() * longest_string_len_chars,),
-                    false,
-                );
-                let data = unsafe { output.as_slice_mut().unwrap() };
-
-                // Copy in the data
-                for (idx, item) in strings.into_iter().enumerate() {
-                    let offset = idx * longest_string_len_chars;
-
-                    let copy_len = longest_string_len_chars.min(item.len());
-
-                    data[offset..offset + copy_len].copy_from_slice(&item);
-                }
-
-                // View it as a unicode array
-                let out: &PyAny = output.into();
-                let out = out
-                    .call_method1("view", (format!("<U{longest_string_len_chars}"),))
-                    .unwrap();
-
-                // Reshape it
-                let out = out
-                    .call_method1("reshape", (PyTuple::new(py, view.shape()),))
-                    .unwrap();
-
-                out.into()
+                PyStringArrayType::from_ndarray(py, view)
             }
             Tensor::I8(item) => item.view().to_pyarray(py).to_object(py),
             Tensor::I16(item) => item.view().to_pyarray(py).to_object(py),

--- a/source/carton-utils-py/Cargo.toml
+++ b/source/carton-utils-py/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "carton-utils-py"
+version = "0.0.1"
+edition = "2021"
+
+[dependencies]
+pyo3 = { version = "0.18", features = ["abi3-py37"]}
+numpy = "0.18"
+ndarray = { version = "0.15" }
+widestring = "1.0.2"

--- a/source/carton-utils-py/README.md
+++ b/source/carton-utils-py/README.md
@@ -1,0 +1,1 @@
+This crate contains utils shared by both `carton-bindings-py` and `carton-runner-py`

--- a/source/carton-utils-py/build.rs
+++ b/source/carton-utils-py/build.rs
@@ -1,0 +1,9 @@
+fn main() {
+    // Rerun only if this file changes (otherwise cargo would rerun this build script all the time)
+    println!("cargo:rerun-if-changed=build.rs");
+
+    #[cfg(target_os = "macos")]
+    println!(
+        "cargo:rustc-link-arg=-Wl,-rpath,/Library/Developer/CommandLineTools/Library/Frameworks"
+    );
+}

--- a/source/carton-utils-py/src/lib.rs
+++ b/source/carton-utils-py/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod tensor;

--- a/source/carton-utils-py/src/tensor.rs
+++ b/source/carton-utils-py/src/tensor.rs
@@ -1,0 +1,124 @@
+use numpy::PyArrayDyn;
+use pyo3::{types::PyTuple, AsPyPointer, FromPyObject, PyAny, PyDowncastError, PyObject, Python};
+
+pub struct PyStringArrayType<'a> {
+    inner: &'a PyAny,
+}
+
+impl<'py> FromPyObject<'py> for PyStringArrayType<'py> {
+    fn extract(ob: &'py PyAny) -> pyo3::PyResult<Self> {
+        unsafe {
+            if numpy::npyffi::PyArray_Check(ob.py(), ob.as_ptr()) == 0 {
+                return Err(PyDowncastError::new(ob, "PyStringArray").into());
+            }
+        }
+
+        let kind: char = ob
+            .getattr("dtype")
+            .unwrap()
+            .getattr("kind")
+            .unwrap()
+            .extract()
+            .unwrap();
+
+        if kind != 'U' {
+            // Only unicode strings are supported
+            return Err(PyDowncastError::new(ob, "PyStringArray").into());
+        }
+
+        Ok(PyStringArrayType { inner: ob })
+    }
+}
+
+impl<'a> PyStringArrayType<'a> {
+    /// Strings are a bit complex and require conversion
+    /// This is unfortunate but necessary because most frameworks have different internal representations of strings
+    pub fn to_ndarray(&self) -> ndarray::ArrayD<String> {
+        let item = self.inner;
+        let itemsize: usize = item.getattr("itemsize").unwrap().extract().unwrap();
+
+        // Each utf32 char is 4 bytes
+        let num_chars_per_item = itemsize / 4;
+
+        let target_shape: Vec<usize> = item.getattr("shape").unwrap().extract().unwrap();
+
+        let item = if target_shape.is_empty() {
+            // Make scalars into 1d arrays
+            item.call_method1("reshape", (1,)).unwrap()
+        } else {
+            item
+        };
+
+        // View as uint32
+        let view = item.call_method1("view", ("uint32",)).unwrap();
+
+        // Convert to np array
+        let view: &PyArrayDyn<u32> = view.extract().unwrap();
+
+        // TODO: handle not contiguous
+        let data = unsafe { view.as_slice().unwrap() };
+
+        // For each elem
+        let data = data
+            .chunks(num_chars_per_item)
+            .map(|item| {
+                let iter = item
+                    .iter()
+                    // Reverse and remove trailing zeros
+                    .rev()
+                    .skip_while(|item| **item == 0);
+
+                // Convert to codepoints
+                let chars: Vec<char> = widestring::decode_utf32(iter.copied())
+                    .map(|v| v.unwrap())
+                    .collect();
+
+                // Reverse again and collect into a string
+                chars.into_iter().rev().collect()
+            })
+            .collect();
+
+        ndarray::ArrayD::from_shape_vec(target_shape, data).unwrap()
+    }
+
+    /// Strings are a bit complex and require conversion
+    /// This is unfortunate but necessary because most frameworks have different internal representations of strings
+    pub fn from_ndarray(py: Python, view: ndarray::ArrayViewD<String>) -> PyObject {
+        // First, convert to utf-32
+        let strings: Vec<Vec<u32>> = view
+            .iter()
+            .map(|item| widestring::encode_utf32(item.chars()).collect())
+            .collect();
+
+        // Find the length of the longest one
+        // TODO: handle empty string arrays
+        let longest_string_len_chars = strings.iter().map(|v| v.len()).max().unwrap();
+
+        // Create a u32 array
+        let output =
+            numpy::PyArray::<u32, _>::zeros(py, (strings.len() * longest_string_len_chars,), false);
+        let data = unsafe { output.as_slice_mut().unwrap() };
+
+        // Copy in the data
+        for (idx, item) in strings.into_iter().enumerate() {
+            let offset = idx * longest_string_len_chars;
+
+            let copy_len = longest_string_len_chars.min(item.len());
+
+            data[offset..offset + copy_len].copy_from_slice(&item);
+        }
+
+        // View it as a unicode array
+        let out: &PyAny = output.into();
+        let out = out
+            .call_method1("view", (format!("<U{longest_string_len_chars}"),))
+            .unwrap();
+
+        // Reshape it
+        let out = out
+            .call_method1("reshape", (PyTuple::new(py, view.shape()),))
+            .unwrap();
+
+        out.into()
+    }
+}


### PR DESCRIPTION
This PR extracts some of the Python string tensor utils from `carton-bindings-py` into a separate `carton-utils-py` crate. This is in preparation for using them in `carton-runner-py` as well.

### Test plan

Existing string tensor tests pass