### PR TITLE
[Python Runner] Add string tensor support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,6 +464,7 @@ dependencies = [
  "carton-runner-interface",
  "carton-runner-packager",
  "carton-utils",
+ "carton-utils-py",
  "clap 4.1.1",
  "escargot",
  "findshlibs",
@@ -487,6 +488,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "toml",
+ "tracing",
  "url",
 ]
 

--- a/source/carton-bindings-py/python/cartonml/utils/transformers.py
+++ b/source/carton-bindings-py/python/cartonml/utils/transformers.py
@@ -1,0 +1,79 @@
+# Utilities to pack huggingface transformers models
+import tempfile
+import transformers
+import os
+import sys
+import dill
+import numpy as np
+
+from .. import pack
+
+from typing import Callable, Any, Dict
+
+from transformers import pipeline, Pipeline
+
+from huggingface_hub import snapshot_download
+
+async def pack_transformers_pipeline(pipeline_task: str, model_name: str, postproc: Callable[[Any], Dict[str, np.ndarray]]):
+    """
+    Packs a carton given the following:
+     - The name of a transformers pipeline task (e.g. 'fill-mask')
+     - A model to use for the pipeline (e.g. 'bert-base-uncased')
+     - A callable that transforms the output of the pipeline into a dict mapping strings to numpy arrays (the output format of the overall model)
+
+    Note: the callable must be pickle-able with `dill`
+    """
+    print("Fetching model from Hugging Face...")
+    dir = tempfile.mkdtemp()
+    model_path = os.path.join(dir, "data")
+
+    # Fetch the model but ignore non-pytorch models
+    snapshot_download(repo_id=model_name, local_dir=model_path, ignore_patterns=["flax_model.msgpack", "model.safetensors", "rust_model.ot", "tf_model.h5"])
+
+    with open(f'{dir}/requirements.txt', 'w') as f:
+        f.write(f"transformers=={transformers.__version__}\n")
+        f.write(f"dill\n")
+        f.write(f"torch\n")
+
+    with open(f'{dir}/postproc.pkl', 'wb') as f:
+        dill.dump(postproc, f, recurse=True, byref=True)
+
+    with open(f'{dir}/main.py', 'w') as f:
+            f.write(f"""
+from transformers import pipeline
+
+import torch
+import dill
+
+class Model:
+    def __init__(self):
+        # Carton will only make a cuda device visible if it's okay to use it
+        # (i.e. a GPU was passed in as a `visible_device` when loading the model)
+        device = 0 if torch.cuda.is_available() else -1
+
+        with open('postproc.pkl', 'rb') as f:
+            self.postproc = dill.load(f)
+
+        self.pipeline = pipeline('{pipeline_task}', model="./data", tokenizer="./data", device=device)
+
+    def infer_with_tensors(self, tensors):
+        seq = list(tensors["input_sequences"])
+        out = self.pipeline(seq)
+        out = self.postproc(out)
+        return out
+
+def get_model():
+    return Model()
+        """)
+
+    model_path = await pack(
+        dir,
+        runner_name="python",
+        required_framework_version=f"={sys.version_info.major}.{sys.version_info.minor}",
+        runner_opts = {
+            "entrypoint_package": "main",
+            "entrypoint_fn": "get_model",
+        },
+    )
+
+    return model_path

--- a/source/carton-bindings-py/tests/test_transformers.py
+++ b/source/carton-bindings-py/tests/test_transformers.py
@@ -1,0 +1,56 @@
+import unittest
+import numpy as np
+import cartonml as carton
+from cartonml.utils.transformers import pack_transformers_pipeline
+
+class Test(unittest.IsolatedAsyncioTestCase):
+    async def test_transformer_text_model(self):
+        def postproc(completions):
+            if len(completions) > 0 and not isinstance(completions[0], list):
+                # We need to wrap in another level
+                completions = [completions]
+
+            alltokens = []
+            allscores = []
+            for batch_item in completions:
+                tokens = []
+                scores = []
+                for completion in batch_item:
+                    tokens.append(completion['token_str'])
+                    scores.append(completion['score'])
+
+                alltokens.append(tokens)
+                allscores.append(scores)
+
+            return {
+                "tokens": np.array(alltokens),
+                "scores": np.array(allscores)
+            }
+
+        model_path = await pack_transformers_pipeline("fill-mask", "bert-base-uncased", postproc)
+        print("Model path!", model_path)
+
+        model = await carton.load(model_path)
+        print("Loaded")
+
+        out = await model.infer({
+            "input_sequences": np.array([
+                "Today is a good [MASK].",
+                "The [MASK] went around the track.",
+            ])
+        })
+
+        print(out)
+
+        scores = out["scores"]
+        tokens = out["tokens"]
+
+        # Pick the tokens with the highest score for each input
+        selections = np.take_along_axis(tokens, scores.argmax(axis=1, keepdims=True), axis=1).flatten()
+
+        self.assertEqual(selections[0], "day")
+        self.assertEqual(selections[1], "car")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/source/carton-runner-py/Cargo.toml
+++ b/source/carton-runner-py/Cargo.toml
@@ -26,6 +26,8 @@ libc = "0.2"
 lunchbox = { version = "0.1", features = ["serde"], default-features = false }
 bytesize = {version = "1.1.0"}
 findshlibs = "0.10.2"
+carton-utils-py = {path = "../carton-utils-py"}
+tracing = "0.1"
 
 # Used by the `build_releases` binary
 semver = {version = "1.0.16"}

--- a/source/carton-runner-py/src/packager.rs
+++ b/source/carton-runner-py/src/packager.rs
@@ -215,7 +215,7 @@ where
         tokio::fs::create_dir_all(&logs_tmp_dir).await.unwrap();
 
         let log_dir = tempfile::tempdir_in(logs_tmp_dir).unwrap();
-        log::info!(target: "slowlog", "Building wheels for non-wheel dependencies using `pip wheel`. This may take a while. See the `pip` logs in {:#?}", log_dir);
+        log::info!(target: "slowlog", "Building wheels for non-wheel dependencies using `pip wheel`. This may take a while. See the `pip` logs in {:#?}", log_dir.path());
 
         let mut sl = slowlog("`pip wheel`", 5).await.without_progress();
 

--- a/source/carton-runner-py/src/pip_utils.rs
+++ b/source/carton-runner-py/src/pip_utils.rs
@@ -41,6 +41,12 @@ async fn ensure_has_pip() {
             "https://files.pythonhosted.org/packages/ab/43/508c403c38eeaa5fc86516eb13bb470ce77601b6d2bbcdb16e26328d0a15/pip-23.0-py3-none-any.whl",
             "b5f88adff801f5ef052bcdef3daa31b55eb67b0fccd6d0106c206fa248e0463c"
         ).await;
+
+        // Make sure we have the `wheel` package
+        install_wheel_and_make_available(
+            "https://files.pythonhosted.org/packages/61/86/cc8d1ff2ca31a312a25a708c891cf9facbad4eae493b3872638db6785eb5/wheel-0.40.0-py3-none-any.whl",
+            "d236b20e7cb522daf2390fa84c55eea81c5c30190f90f29ae2ca1ad8355bf247"
+        ).await;
     }).await;
 }
 
@@ -161,5 +167,20 @@ mod tests {
 
         let p = String::from_utf8(output).unwrap();
         assert_eq!("23.0", p.trim());
+    }
+
+    #[tokio::test]
+    async fn test_wheel_subprocess() {
+        ensure_has_pip().await;
+
+        let output = Command::new(get_executable_path().unwrap().as_str())
+            .args(["-c", "import wheel; print(wheel.__version__)"])
+            .output()
+            .await
+            .unwrap()
+            .stdout;
+
+        let p = String::from_utf8(output).unwrap();
+        assert_eq!("0.40.0", p.trim());
     }
 }

--- a/source/carton-runner-py/src/preload_cuda.py
+++ b/source/carton-runner-py/src/preload_cuda.py
@@ -1,0 +1,60 @@
+# Based on https://gist.github.com/qxcv/183c2d6cd81f7028b802b232d6a9dd62
+
+"""Hack to load CUDA variables shipped via PyPI. Addresses this Torch bug:
+
+https://github.com/pytorch/pytorch/issues/101314
+
+Copied from PyTorch's __init__.py file, with modifications:
+
+https://github.com/pytorch/pytorch/blob/main/torch/__init__.py
+
+Copyright notice below is from Torch.
+"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of the PyTorch source tree.
+import ctypes
+import sys
+import os
+import platform
+from typing import Dict
+
+def _preload_cuda_deps(lib_folder: str, lib_name: str) -> None:
+    """Preloads cuda deps if they could not be found otherwise."""
+    # Should only be called on Linux if default path resolution have failed
+    assert platform.system() == 'Linux', 'Should only be called on Linux'
+    import glob
+    lib_path = None
+    for path in sys.path:
+        nvidia_path = os.path.join(path, 'nvidia')
+        if not os.path.exists(nvidia_path):
+            continue
+        candidate_lib_paths = glob.glob(os.path.join(nvidia_path, lib_folder, 'lib', lib_name))
+        if candidate_lib_paths and not lib_path:
+            lib_path = candidate_lib_paths[0]
+        if lib_path:
+            break
+    if not lib_path:
+        # raise ValueError(f"{lib_name} not found in the system path {sys.path}")
+        return
+    ctypes.CDLL(lib_path)
+
+
+def preload_cuda_deps() -> None:
+    cuda_libs: Dict[str, str] = {
+        'cublas': 'libcublas.so.*[0-9]',
+        'cudnn': 'libcudnn.so.*[0-9]',
+        'cuda_nvrtc': 'libnvrtc.so.*[0-9].*[0-9]',
+        'cuda_runtime': 'libcudart.so.*[0-9].*[0-9]',
+        'cuda_cupti': 'libcupti.so.*[0-9].*[0-9]',
+        'cufft': 'libcufft.so.*[0-9]',
+        'curand': 'libcurand.so.*[0-9]',
+        'cusolver': 'libcusolver.so.*[0-9]',
+        'cusparse': 'libcusparse.so.*[0-9]',
+        'nccl': 'libnccl.so.*[0-9]',
+        'nvtx': 'libnvToolsExt.so.*[0-9]',
+    }
+    for lib_folder, lib_name in cuda_libs.items():
+        _preload_cuda_deps(lib_folder, lib_name)

--- a/source/carton-utils-py/Cargo.toml
+++ b/source/carton-utils-py/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 edition = "2021"
 
 [dependencies]
-pyo3 = { version = "0.18", features = ["abi3-py37"]}
+pyo3 = { version = "0.18" }
 numpy = "0.18"
 ndarray = { version = "0.15" }
 widestring = "1.0.2"


### PR DESCRIPTION
This PR adds string tensor support to `carton-runner-py`. It also adds a test that packs and runs `bert-base-uncased` (with string input and output).

Some minor additional changes were included to make running and debugging the model easier:
- Added python tracebacks to error messages
- Added tracing support
- Added `slowlog` for copying large files

Finally, there's a bug in Torch 2.x when python packages are laid out in independent directories (https://github.com/pytorch/pytorch/issues/101314). This PR addresses that issue by attempting to preload cuda if nvidia libs are on `sys.path`.