### PR TITLE
[Python Bindings] Allow passing an index to `visible_device`

### DIFF
--- a/source/carton-bindings-py/src/lib.rs
+++ b/source/carton-bindings-py/src/lib.rs
@@ -1,8 +1,8 @@
 use std::{collections::HashMap, sync::Arc};
 
 use conversions::{
-    create_load_opts, create_pack_opts, CartonInfo, Example, LazyLoadedMiscFile, LazyLoadedTensor,
-    PyRunnerOpt, RunnerInfo, SelfTest, TensorSpec,
+    create_load_opts, create_pack_opts, CartonInfo, Device, Example, LazyLoadedMiscFile,
+    LazyLoadedTensor, PyRunnerOpt, RunnerInfo, SelfTest, TensorSpec,
 };
 use pyo3::{exceptions::PyValueError, prelude::*, types::PyDict};
 use tensor::{tensor_to_py, SupportedTensorType};
@@ -79,7 +79,7 @@ impl Carton {
 fn load(
     py: Python,
     path: String,
-    visible_device: Option<String>,
+    visible_device: Option<Device>,
     override_runner_name: Option<String>,
     override_required_framework_version: Option<String>,
     override_runner_opts: Option<HashMap<String, PyRunnerOpt>>,
@@ -121,7 +121,7 @@ fn load_unpacked(
     self_tests: Option<Vec<SelfTest>>,
     examples: Option<Vec<Example>>,
     misc_files: Option<HashMap<String, Vec<u8>>>,
-    visible_device: Option<String>,
+    visible_device: Option<Device>,
 ) -> PyResult<&PyAny> {
     pyo3_asyncio::tokio::future_into_py(py, async move {
         let pack_opts = create_pack_opts(

--- a/source/carton/src/types.rs
+++ b/source/carton/src/types.rs
@@ -93,7 +93,7 @@ impl Device {
     }
 
     #[cfg(not(target_family = "wasm"))]
-    fn maybe_from_index(i: u32) -> Self {
+    pub fn maybe_from_index(i: u32) -> Self {
         if let Some(nvml) = NVML.as_ref() {
             if let Ok(device) = nvml.device_by_index(i) {
                 if let Ok(uuid) = device.uuid() {


### PR DESCRIPTION
This PR enables passing a GPU index to visible_device (instead of only allowing strings)