### PR TITLE
Add a runner that uses `rust-bert`

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@ steps:
   - name: "Native Build x86_64-unknown-linux-gnu"
     agents:
       queue: default
-    command: "python3 ci/build.py --target x86_64-unknown-linux-gnu"
+    command: "python3 ci/build.py --release --target x86_64-unknown-linux-gnu"
     plugins:
       - docker-compose#v3.7.0:
           run: x86_64
@@ -11,7 +11,7 @@ steps:
   - name: "Native Build aarch64-unknown-linux-gnu"
     agents:
       queue: arm64
-    command: "python3 ci/build.py --target aarch64-unknown-linux-gnu"
+    command: "python3 ci/build.py --release --target aarch64-unknown-linux-gnu"
     plugins:
       - docker-compose#v3.7.0:
           run: arm64

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,3 +6,6 @@ rustflags = ["--cfg", "tokio_unstable"]
 # Set a default target so that build caches are saved correctly when switching targets
 # https://doc.rust-lang.org/cargo/guide/build-cache.html
 target = ["x86_64-unknown-linux-gnu"]
+
+[env]
+LIBTORCH = {value = "./libtorch", relative = true}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     container:
       # TODO: only on linux
-      image: vpanyam/manylinux2014-rust-python310:x86_64
+      image: vpanyam/manylinux_2_28-rust-python310:x86_64
     strategy:
       matrix:
         include:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target/
 .vscode/
+libtorch/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,12 +9,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aes"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
  "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if",
  "once_cell",
  "version_check",
 ]
@@ -249,6 +271,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,6 +343,28 @@ dependencies = [
  "cc",
  "libc",
  "pkg-config",
+]
+
+[[package]]
+name = "cached-path"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "097968e38f1319207f057d0f4d76452e4f4f847a5de61c5215379f297fa034f3"
+dependencies = [
+ "flate2",
+ "fs2",
+ "glob",
+ "indicatif",
+ "log",
+ "rand",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tar",
+ "tempfile",
+ "thiserror",
+ "zip",
 ]
 
 [[package]]
@@ -519,6 +569,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "carton-runner-rust-bert"
+version = "0.0.1"
+dependencies = [
+ "async-trait",
+ "bytesize",
+ "carton",
+ "carton-runner-interface",
+ "carton-runner-packager",
+ "carton-utils",
+ "clap 4.1.1",
+ "env_logger",
+ "escargot",
+ "fetch-deps",
+ "log",
+ "lunchbox",
+ "ndarray",
+ "rust-bert",
+ "semver 1.0.16",
+ "serde",
+ "serde_json",
+ "serde_plain",
+ "target-lexicon",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
 name = "carton-utils"
 version = "0.0.1"
 dependencies = [
@@ -623,7 +700,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
 dependencies = [
  "ciborium-io",
- "half",
+ "half 1.8.2",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -695,6 +782,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d79fbe8970a77e3e34151cc13d3b3e248aa0faaecb9f6091fa07ebefe5ad60"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "console-api"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -739,6 +838,12 @@ dependencies = [
  "cfg-if",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "core-foundation"
@@ -856,6 +961,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -863,6 +974,27 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "csv"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "626ae34994d3d8d668f4269922248239db4ae42d538b14c398b74a52208e8086"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -916,7 +1048,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
 dependencies = [
  "cfg-if",
- "hashbrown",
+ "hashbrown 0.12.3",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -989,6 +1121,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1033,9 +1171,9 @@ dependencies = [
 
 [[package]]
 name = "escargot"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5584ba17d7ab26a8a7284f13e5bd196294dd2f2d79773cff29b9e9edef601a6"
+checksum = "768064bd3a0e2bedcba91dc87ace90beea91acc41b6a01a3ca8e9aa8827461bf"
 dependencies = [
  "log",
  "once_cell",
@@ -1050,6 +1188,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "fetch-deps"
+version = "0.0.1"
+dependencies = [
+ "carton-utils",
+ "tempfile",
+ "tokio",
 ]
 
 [[package]]
@@ -1114,6 +1261,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -1227,6 +1384,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "h2"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1252,12 +1415,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
+name = "half"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc52e53916c08643f1b56ec082790d1e86a32e58dc5268f897f313fbae7b4872"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash 0.8.3",
 ]
 
 [[package]]
@@ -1448,7 +1630,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b"
+dependencies = [
+ "console",
+ "lazy_static",
+ "number_prefix",
+ "regex",
 ]
 
 [[package]]
@@ -1464,6 +1658,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a898e4b7951673fce96614ce5751d13c40fc5674bc2d759288e46c3ab62598b3"
 dependencies = [
  "cfb",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -1856,6 +2059,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "numpy"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1938,13 +2147,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc2dbde8f8a79f2102cc474ceb0ad68e3b80b85289ea62389b60e66777e4213"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "ordered-multimap"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
 dependencies = [
  "dlv-list",
- "hashbrown",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -1983,6 +2201,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
+dependencies = [
+ "base64ct",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1993,6 +2222,18 @@ name = "path-clean"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecba01bf2678719532c5e3059e0b5f0811273d94b397088b82e3bd0a78c78fdd"
+
+[[package]]
+name = "pbkdf2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+dependencies = [
+ "digest",
+ "hmac",
+ "password-hash",
+ "sha2",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -2146,6 +2387,12 @@ dependencies = [
  "bytes",
  "prost",
 ]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "pyo3"
@@ -2411,6 +2658,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-bert"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8792cccdf842159ef04a35f247df68ccc42192e9a67e389e6cd0f1a83970a6a0"
+dependencies = [
+ "cached-path",
+ "dirs",
+ "half 2.3.1",
+ "lazy_static",
+ "ordered-float",
+ "regex",
+ "rust_tokenizers",
+ "serde",
+ "serde_json",
+ "tch",
+ "thiserror",
+ "uuid",
+]
+
+[[package]]
 name = "rust-ini"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2449,6 +2716,26 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "url",
+]
+
+[[package]]
+name = "rust_tokenizers"
+version = "8.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f367f6b13bc686e822237b97caeb4b2e366dd1936ec204f11d266ede402c31b"
+dependencies = [
+ "csv",
+ "hashbrown 0.13.2",
+ "itertools",
+ "lazy_static",
+ "protobuf",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "unicode-normalization",
+ "unicode-normalization-alignments",
 ]
 
 [[package]]
@@ -2501,6 +2788,16 @@ name = "ryu"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+
+[[package]]
+name = "safetensors"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8cbd90c388a0b028565d8ad22e090101599d951c6b5f105b4f7772721a9d5f"
+dependencies = [
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "same-file"
@@ -2654,6 +2951,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_plain"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6018081315db179d0ce57b1fe4b62a12a0028c9cf9bbef868c9cf477b3c34ae"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2663,6 +2969,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -2812,6 +3129,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd1ba337640d60c3e96bc6f0638a939b9c9a7f2c316a1598c279828b3d1dc8c5"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "tch"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cbd9ce6fb581a1b918db880b649d1364b50f7f6717eda8497bcdc929cddd4b9"
+dependencies = [
+ "half 2.3.1",
+ "lazy_static",
+ "libc",
+ "ndarray",
+ "rand",
+ "safetensors",
+ "thiserror",
+ "torch-sys",
+ "zip",
 ]
 
 [[package]]
@@ -3055,6 +3389,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "torch-sys"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b2b81a479510717464df1d07c02cb4aebb26539a39b5db6637dda114a476cb"
+dependencies = [
+ "anyhow",
+ "cc",
+ "libc",
+ "zip",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3223,6 +3569,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-normalization-alignments"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3256,6 +3611,9 @@ name = "uuid"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "valuable"
@@ -3638,6 +3996,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
 dependencies = [
  "lzma-sys",
+]
+
+[[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "aes",
+ "byteorder",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
+ "hmac",
+ "pbkdf2",
+ "sha1",
+ "time 0.3.19",
+ "zstd",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,14 @@ members = [
     "source/carton-macros",
     "source/carton-runner-noop",
     "source/carton-runner-py",
+    "source/carton-runner-rust-bert",
     "source/carton-utils-py",
     "source/anywhere",
+    "source/fetch-deps",
 ]
 
 [profile.release]
-lto = true
+lto = "thin"
 debug = true
 
 [patch.crates-io]

--- a/source/carton-runner-packager/Cargo.toml
+++ b/source/carton-runner-packager/Cargo.toml
@@ -11,7 +11,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 url = "2.3.1"
 log = "0.4"
-escargot = "0.5.7"
+escargot = "0.5.8"
 semver = {version = "1.0.16", features = ["serde"]}
 target-lexicon = {version = "0.12.7", features = ["serde_support"]}
 chrono = {version = "0.4.23", features = ["serde"]}

--- a/source/carton-runner-py/Cargo.toml
+++ b/source/carton-runner-py/Cargo.toml
@@ -32,7 +32,7 @@ tracing = "0.1"
 # Used by the `build_releases` binary
 semver = {version = "1.0.16"}
 target-lexicon = {version = "0.12.7", features = ["serde_support"]}
-escargot = "0.5.7"
+escargot = "0.5.8"
 carton-runner-packager = { path = "../carton-runner-packager" }
 clap = { version = "4.0.29", features = ["derive"] }
 

--- a/source/carton-runner-rust-bert/Cargo.toml
+++ b/source/carton-runner-rust-bert/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "carton-runner-rust-bert"
+version = "0.0.1"
+edition = "2021"
+
+[dependencies]
+carton-runner-interface = { path = "../carton-runner-interface" }
+tokio = { version = "1", features = ["full"] }
+serde = { version = "1.0", features = ["derive"] }
+rust-bert = "0.21.0"
+lunchbox = { version = "0.1", features = ["serde"], default-features = false }
+tempfile = "3.3.0"
+ndarray = { version = "0.15", features = ["serde"] }
+serde_plain = "1.0.1"
+serde_json = "1"
+async-trait = "0.1"
+log = "0.4"
+
+# Used by the `build_releases` binary
+semver = {version = "1.0.16"}
+target-lexicon = {version = "0.12.7", features = ["serde_support"]}
+escargot = "0.5.8"
+carton-runner-packager = { path = "../carton-runner-packager" }
+clap = { version = "4.0.29", features = ["derive"] }
+env_logger = "0.9"
+fetch-deps = { path = "../fetch-deps" }
+
+# TODO: this is very much not ideal, but we use it to pack models
+carton = { path = "../carton" }
+carton-utils = { path = "../carton-utils" }
+bytesize = {version = "1.1.0"}
+

--- a/source/carton-runner-rust-bert/README.md
+++ b/source/carton-runner-rust-bert/README.md
@@ -1,0 +1,1 @@
+This runner runs models with [rust-bert](https://github.com/guillaume-be/rust-bert), a rust port of Huggingface Transformers

--- a/source/carton-runner-rust-bert/build.rs
+++ b/source/carton-runner-rust-bert/build.rs
@@ -1,0 +1,36 @@
+use std::path::PathBuf;
+
+fn main() {
+    // Rerun only if this file changes (otherwise cargo would rerun this build script all the time)
+    println!("cargo:rerun-if-changed=build.rs");
+
+    // This is a bit hacky, but we need to set LD_LIBRARY_PATH at runtime for cargo test
+    // We can't set this in .cargo/config.toml so we do it here
+    // TODO: see if we can improve this
+    let libdir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join("libtorch")
+        .join("lib");
+
+    #[cfg(not(target_os = "macos"))]
+    println!(
+        "cargo:rustc-env=LD_LIBRARY_PATH={}",
+        libdir.to_str().unwrap()
+    );
+
+    #[cfg(target_os = "macos")]
+    println!(
+        "cargo:rustc-env=DYLD_FALLBACK_LIBRARY_PATH={}",
+        libdir.to_str().unwrap()
+    );
+
+    // Add the bundled libtorch lib dir to the binary's rpath
+    #[cfg(not(target_os = "macos"))]
+    println!("cargo:rustc-link-arg=-Wl,-rpath,$ORIGIN/libtorch/lib");
+
+    #[cfg(target_os = "macos")]
+    println!("cargo:rustc-link-arg=-Wl,-rpath,@loader_path/libtorch/lib");
+}

--- a/source/carton-runner-rust-bert/src/bin/build_rust_bert_releases.rs
+++ b/source/carton-runner-rust-bert/src/bin/build_rust_bert_releases.rs
@@ -1,0 +1,78 @@
+//! A binary that builds the release packages
+
+use std::{path::PathBuf, time::SystemTime};
+
+use carton_runner_interface::slowlog::slowlog;
+use carton_runner_packager::{discovery::RunnerInfo, DownloadItem};
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+struct Args {
+    /// The local folder to output to
+    #[arg(long)]
+    output_path: PathBuf,
+}
+
+#[tokio::main]
+async fn main() {
+    // Logging (for long running downloads)
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    // Parse args
+    let args = Args::parse();
+
+    log::info!("Starting runner build...");
+    let mut sl = slowlog("Building runner", 5).await.without_progress();
+    // Build the runner
+    let runner_path = escargot::CargoBuild::new()
+        .package("carton-runner-rust-bert")
+        .bin("carton-runner-rust-bert")
+        .current_release()
+        .current_target()
+        .env_remove("LIBTORCH")
+        .run()
+        .unwrap()
+        .path()
+        .display()
+        .to_string();
+    sl.done();
+    log::info!("Runner Path: {}", runner_path);
+
+    let package = carton_runner_packager::package(
+        RunnerInfo {
+            runner_name: "rust-bert".to_string(),
+            framework_version: semver::Version::new(0, 21, 0),
+            runner_compat_version: 1,
+            runner_interface_version: 1,
+            runner_release_date: SystemTime::now().into(),
+            runner_path,
+            platform: target_lexicon::HOST.to_string(),
+        },
+        vec![DownloadItem {
+            url: fetch_deps::libtorch::URL.to_string(),
+            sha256: fetch_deps::libtorch::SHA256.to_string(),
+
+            // The zip file includes a libtorch folder
+            relative_path: "./".to_string(),
+        }],
+    )
+    .await;
+
+    // Write the zip file to our output dir
+    tokio::fs::write(
+        &args
+            .output_path
+            .join(format!("{}.zip", package.get_data_sha256())),
+        package.get_data(),
+    )
+    .await
+    .unwrap();
+
+    // Write the package config so it can be loaded when the runner zip files will be uploaded
+    tokio::fs::write(
+        &args.output_path.join(format!("{}.json", package.get_id())),
+        serde_json::to_string_pretty(&package).unwrap(),
+    )
+    .await
+    .unwrap();
+}

--- a/source/carton-runner-rust-bert/src/lib.rs
+++ b/source/carton-runner-rust-bert/src/lib.rs
@@ -1,0 +1,96 @@
+use std::{collections::HashMap, path::Path};
+
+use async_trait::async_trait;
+use carton_runner_interface::{slowlog::slowlog, types::Tensor};
+use lunchbox::{types::ReadableFile, ReadableFileSystem};
+use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncWriteExt, BufReader, BufWriter};
+use translate::CartonTranslationConfig;
+
+pub mod translate;
+
+#[derive(Serialize, Deserialize)]
+pub enum ModelConfig {
+    Translation(CartonTranslationConfig),
+    Summarization,
+    ZeroShotClassification,
+    SentimentAnalysis,
+    NER,
+    POSTagging,
+    QuestionAnswering,
+    KeywordExtraction,
+    TextClassification,
+    FillMask,
+    SentenceEmbeddings,
+}
+
+#[async_trait]
+pub trait ModelFromConfig {
+    type ModelType: Model;
+
+    async fn load<F>(self, fs: &F) -> Self::ModelType
+    where
+        F: ReadableFileSystem + Send + Sync,
+        F::FileType: ReadableFile + Unpin + Send + Sync;
+}
+
+pub trait Model {
+    fn infer(&self, tensors: HashMap<String, Tensor>) -> HashMap<String, Tensor>;
+}
+
+pub(crate) async fn copy_to_local<F>(fs: &F, base: &Path, path: &str)
+where
+    F: ReadableFileSystem,
+    F::FileType: ReadableFile + Unpin,
+{
+    let p = Path::new(path);
+
+    // Create intermediate dirs as necessary
+    if let Some(parent_dir) = p.parent() {
+        tokio::fs::create_dir_all(base.join(parent_dir))
+            .await
+            .unwrap();
+    }
+
+    let mut sl = slowlog(format!("Loading file '{path}'"), 5)
+        .await
+        .without_progress();
+    let f = fs.open(path).await.unwrap();
+    let out = tokio::fs::File::create(base.join(path)).await.unwrap();
+
+    // 1mb buffer
+    let mut br = BufReader::with_capacity(1_000_000, f);
+    let mut bw = BufWriter::with_capacity(1_000_000, out);
+
+    // TODO: don't unwrap
+    tokio::io::copy(&mut br, &mut bw).await.unwrap();
+    bw.flush().await.unwrap();
+    sl.done();
+}
+
+pub(crate) async fn download_file<P: AsRef<std::path::Path>>(
+    url: &str,
+    sha256: &str,
+    download_path: P,
+) -> carton_utils::error::Result<()> {
+    let mut sl = slowlog(format!("Downloading file '{url}'"), 5).await;
+    let out = carton_utils::download::cached_download(
+        url,
+        sha256,
+        download_path,
+        |total| {
+            if let Some(size) = total {
+                sl.set_total(Some(bytesize::ByteSize(size)));
+            }
+        },
+        |downloaded| {
+            sl.set_progress(Some(bytesize::ByteSize(downloaded)));
+        },
+    )
+    .await;
+
+    // Let the logging task know we're done downloading
+    sl.done();
+
+    out
+}

--- a/source/carton-runner-rust-bert/src/main.rs
+++ b/source/carton-runner-rust-bert/src/main.rs
@@ -1,0 +1,118 @@
+use std::collections::HashMap;
+
+use carton_runner_interface::server::{init_runner, RequestData, ResponseData, SealHandle};
+use carton_runner_rust_bert::{Model, ModelConfig, ModelFromConfig};
+use lunchbox::ReadableFileSystem;
+
+#[tokio::main]
+async fn main() {
+    let mut server = init_runner().await;
+
+    let mut sealed = HashMap::new();
+    let mut seal_counter = 0;
+
+    let mut model: Option<Box<dyn Model>> = None;
+
+    while let Some(req) = server.get_next_request().await {
+        let req_id = req.id;
+        match req.data {
+            RequestData::Load {
+                fs,
+                runner_name,
+                required_framework_version,
+                runner_compat_version,
+                runner_opts,
+                visible_device,
+                carton_manifest_hash,
+            } => {
+                // Load the model config
+                let fs = server.get_readonly_filesystem(fs).await.unwrap();
+                let config: ModelConfig =
+                    serde_json::from_slice(&fs.read("config.json").await.unwrap()).unwrap();
+
+                match config {
+                    ModelConfig::Translation(config) => {
+                        model = Some(Box::new(config.load(&fs).await))
+                    }
+                    ModelConfig::Summarization => todo!(),
+                    ModelConfig::ZeroShotClassification => todo!(),
+                    ModelConfig::SentimentAnalysis => todo!(),
+                    ModelConfig::NER => todo!(),
+                    ModelConfig::POSTagging => todo!(),
+                    ModelConfig::QuestionAnswering => todo!(),
+                    ModelConfig::KeywordExtraction => todo!(),
+                    ModelConfig::TextClassification => todo!(),
+                    ModelConfig::FillMask => todo!(),
+                    ModelConfig::SentenceEmbeddings => todo!(),
+                }
+
+                server
+                    .send_response_for_request(req_id, ResponseData::Load)
+                    .await
+                    .unwrap();
+            }
+            RequestData::Pack {
+                fs,
+                input_path,
+                temp_folder,
+            } => {
+                // This should basically be a noop since the structure of the input folder should be the same as the target
+                // Just return the input path
+                server
+                    .send_response_for_request(
+                        req_id,
+                        ResponseData::Pack {
+                            output_path: input_path,
+                        },
+                    )
+                    .await
+                    .unwrap();
+            }
+            RequestData::Seal { tensors } => {
+                sealed.insert(seal_counter, tensors);
+
+                server
+                    .send_response_for_request(
+                        req_id,
+                        ResponseData::Seal {
+                            handle: SealHandle::new(seal_counter),
+                        },
+                    )
+                    .await
+                    .unwrap();
+
+                seal_counter += 1;
+            }
+            RequestData::InferWithTensors { tensors } => {
+                // TODO: error handling
+                let result = model.as_ref().map(|m| m.infer(tensors));
+
+                server
+                    .send_response_for_request(
+                        req_id,
+                        ResponseData::Infer {
+                            tensors: result.unwrap(),
+                        },
+                    )
+                    .await
+                    .unwrap();
+            }
+            RequestData::InferWithHandle { handle } => {
+                // TODO: error handling
+                let result = sealed
+                    .remove(&handle.get())
+                    .and_then(|tensors| model.as_ref().map(|m| m.infer(tensors)));
+
+                server
+                    .send_response_for_request(
+                        req_id,
+                        ResponseData::Infer {
+                            tensors: result.unwrap(),
+                        },
+                    )
+                    .await
+                    .unwrap();
+            }
+        }
+    }
+}

--- a/source/carton-runner-rust-bert/src/translate.rs
+++ b/source/carton-runner-rust-bert/src/translate.rs
@@ -1,0 +1,272 @@
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+use carton_runner_interface::types::{Tensor, TensorStorage};
+use lunchbox::{types::ReadableFile, ReadableFileSystem};
+use rust_bert::{
+    pipelines::{
+        common::{ModelResource, ModelType},
+        translation::{Language, TranslationConfig, TranslationModel},
+    },
+    resources::LocalResource,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{copy_to_local, Model, ModelFromConfig};
+
+/// Config for a translation model
+#[derive(Serialize, Deserialize)]
+pub struct CartonTranslationConfig {
+    model_type: ModelType,
+    model_path: String,
+    config_path: String,
+    vocab_path: String,
+    merges_path: Option<String>,
+    source_languages: Vec<Language>,
+    target_languages: Vec<Language>,
+}
+
+pub struct CartonTranslationModel {
+    _tempdir: tempfile::TempDir,
+    model: TranslationModel,
+}
+
+#[async_trait]
+impl ModelFromConfig for CartonTranslationConfig {
+    type ModelType = CartonTranslationModel;
+
+    async fn load<F>(self, fs: &F) -> Self::ModelType
+    where
+        F: ReadableFileSystem + Send + Sync,
+        F::FileType: ReadableFile + Unpin + Send + Sync,
+    {
+        let td = tempfile::tempdir().unwrap();
+        let base = td.path();
+        // Load all the model resources
+        tokio::join!(
+            copy_to_local(fs, base, &self.model_path),
+            copy_to_local(fs, base, &self.config_path),
+            copy_to_local(fs, base, &self.vocab_path),
+            async {
+                if let Some(p) = &self.merges_path {
+                    copy_to_local(fs, base, p).await;
+                }
+            },
+        );
+
+        log::trace!("Loading translation model...");
+        let translation_config = TranslationConfig::new(
+            self.model_type,
+            ModelResource::Torch(td.path().join(self.model_path).into()),
+            LocalResource::from(td.path().join(self.config_path)),
+            LocalResource::from(td.path().join(self.vocab_path)),
+            self.merges_path
+                .map(|p| LocalResource::from(td.path().join(p))),
+            self.source_languages,
+            self.target_languages,
+            // Defaults to cuda if available
+            None,
+        );
+
+        let model = TranslationModel::new(translation_config).unwrap();
+
+        CartonTranslationModel {
+            _tempdir: td,
+            model,
+        }
+    }
+}
+
+impl Model for CartonTranslationModel {
+    fn infer(&self, tensors: HashMap<String, Tensor>) -> HashMap<String, Tensor> {
+        // TODO: don't unwrap
+        let input_tensor = tensors.get("input").unwrap();
+        let source_language = tensors.get("source_language").unwrap();
+        let target_language = tensors.get("target_language").unwrap();
+
+        // Get all of them as string tensors
+        if let Tensor::String(input_tensor) = input_tensor {
+            let input_tensor = input_tensor.view();
+            let mut output_tensor =
+                TensorStorage::new(input_tensor.shape().iter().map(|v| (*v) as _).collect());
+            let mut output_view = output_tensor.view_mut();
+
+            if let Tensor::String(source_language) = source_language {
+                let source_language = source_language.view();
+
+                if let Tensor::String(target_language) = target_language {
+                    let target_language = target_language.view();
+
+                    for batch_idx in 0..input_tensor.len_of(ndarray::Axis(0)) {
+                        let indexed_input_tensor =
+                            input_tensor.index_axis(ndarray::Axis(0), batch_idx);
+                        let data = indexed_input_tensor.as_slice().unwrap();
+                        let sl = source_language.get(batch_idx).unwrap();
+                        let tl = target_language.get(batch_idx).unwrap();
+
+                        let result = self
+                            .model
+                            .translate(
+                                data,
+                                serde_plain::from_str::<Option<Language>>(sl).unwrap(),
+                                serde_plain::from_str::<Option<Language>>(tl).unwrap(),
+                            )
+                            .unwrap();
+                        log::trace!(
+                            "Translation: {data:#?} from {sl} to {tl} provides {result:#?}"
+                        );
+
+                        // Set the values of the output tensor
+                        let mut indexed_output_view =
+                            output_view.index_axis_mut(ndarray::Axis(0), batch_idx);
+                        let sliced_output_view = indexed_output_view.as_slice_mut().unwrap();
+                        sliced_output_view.clone_from_slice(&result);
+                    }
+
+                    let mut out = HashMap::new();
+                    out.insert("output".to_owned(), Tensor::String(output_tensor));
+                    return out;
+                }
+            }
+        }
+
+        // TODO: don't do this
+        panic!("Unexpected input");
+    }
+}
+
+pub mod pack {
+    use std::path::PathBuf;
+
+    use carton::{
+        info::{DataType, Dimension, Example, RunnerInfo, Shape, TensorOrMisc, TensorSpec},
+        types::{GenericStorage, PackOpts, Tensor},
+    };
+    use rust_bert::{m2m_100::M2M100SourceLanguages, pipelines::translation::Language};
+
+    use crate::{download_file, ModelConfig};
+
+    pub async fn pack_m2m100() -> PathBuf {
+        // Replace ChineseMandarin with Chinese
+        let languages: Vec<_> = M2M100SourceLanguages::M2M100_418M
+            .iter()
+            .map(|item| match item {
+                Language::ChineseMandarin => Language::Chinese,
+                other => *other,
+            })
+            .collect();
+
+        let model_config = ModelConfig::Translation(super::CartonTranslationConfig {
+            model_type: rust_bert::pipelines::common::ModelType::M2M100,
+            model_path: "./model/rust_model.ot".into(),
+            config_path: "./model/config.json".into(),
+            vocab_path: "./model/vocab.json".into(),
+            merges_path: Some("./model/sentencepiece.bpe.model".into()),
+            source_languages: languages.clone(),
+            target_languages: languages.clone(),
+        });
+
+        // Create a tempdir to pack
+        let dir = tempfile::tempdir().unwrap();
+
+        // Write the config
+        let serialized = serde_json::to_vec(&model_config).unwrap();
+        tokio::fs::write(dir.path().join("config.json"), serialized)
+            .await
+            .unwrap();
+
+        // Add the model resources
+        let model_dir = dir.path().join("model");
+        tokio::fs::create_dir(&model_dir).await.unwrap();
+        let res = tokio::join!(
+            download_file(
+                "https://huggingface.co/facebook/m2m100_418M/resolve/a84767a43c9159c5c15eb3964dce2179684647f6/rust_model.ot".into(),
+                "f170f6a277d00b20144fa6dac6ecd781c5a5e66844c022244437dd2da3a83655".into(),
+                model_dir.join("rust_model.ot"),
+            ),
+            download_file(
+                "https://huggingface.co/facebook/m2m100_418M/resolve/a84767a43c9159c5c15eb3964dce2179684647f6/config.json".into(),
+                "df0ae43e4e4b0d7e3c97b7f447857a70ef6b6a2aa1f145cedbcc730d95f67134".into(),
+                model_dir.join("config.json"),
+            ),
+            download_file(
+                "https://huggingface.co/facebook/m2m100_418M/resolve/a84767a43c9159c5c15eb3964dce2179684647f6/vocab.json".into(),
+                "b6e77e474aeea8f441363aca7614317c06381f3eacfe10fb9856d5081d1074cc".into(),
+                model_dir.join("vocab.json"),
+            ),
+            download_file(
+                "https://huggingface.co/facebook/m2m100_418M/resolve/a84767a43c9159c5c15eb3964dce2179684647f6/sentencepiece.bpe.model".into(),
+                "d8f7c76ed2a5e0822be39f0a4f95a55eb19c78f4593ce609e2edbc2aea4d380a".into(),
+                model_dir.join("sentencepiece.bpe.model"),
+            ),
+        );
+
+        // TODO: better error handling
+        res.0.unwrap();
+        res.1.unwrap();
+        res.2.unwrap();
+        res.3.unwrap();
+
+        // Pack the model and return the path
+        carton::Carton::pack::<GenericStorage>(dir.path().to_str().unwrap().to_owned(), PackOpts {
+            model_name: Some("M2M100".into()),
+            short_description: Some("M2M100 is a model that can translate directly between any pair of 100 languages.".into()),
+            model_description: Some("See [here](https://about.fb.com/news/2020/10/first-multilingual-machine-translation-model/) for more details. M2M100 supports the following languages:\n".to_owned() + &languages.iter().map(|l| format!("- {}", serde_plain::to_string(l).unwrap())).collect::<Vec<_>>().join("\n")),
+            required_platforms: None,
+            inputs: Some(vec![
+                TensorSpec {
+                    name: "input".into(),
+                    dtype: DataType::String,
+                    shape: Shape::Shape(vec![Dimension::Symbol("N".into()), Dimension::Any]),
+                    description: Some("The strings to translate as batches grouped by language".into()),
+                    internal_name: None
+                },
+                TensorSpec {
+                    name: "source_language".into(),
+                    dtype: DataType::String,
+                    shape: Shape::Shape(vec![Dimension::Symbol("N".into())]),
+                    description: Some("The source language (or empty string) for every batch item".into()),
+                    internal_name: None
+                },
+                TensorSpec {
+                    name: "target_language".into(),
+                    dtype: DataType::String,
+                    shape: Shape::Shape(vec![Dimension::Symbol("N".into())]),
+                    description: Some("The target language for every batch item".into()),
+                    internal_name: None
+                }
+            ]),
+            outputs: Some(vec![
+                TensorSpec {
+                    name: "output".into(),
+                    dtype: DataType::String,
+                    shape: Shape::Shape(vec![Dimension::Symbol("N".into()), Dimension::Any]),
+                    description: Some("The translated strings in the same shape as `input`".into()),
+                    internal_name: None
+                },
+            ]),
+            self_tests: None,
+            examples: Some(vec![
+                Example {
+                    name: Some("quickstart".into()),
+                    description: Some("Translation from Hindi to French and Chinese to English".into()),
+                    inputs: [
+                        ("input".into(), TensorOrMisc::Tensor(Tensor::String(ndarray::ArrayD::from_shape_vec(ndarray::IxDyn(&[2, 1]), vec!["जीवन एक चॉकलेट बॉक्स की तरह है।".into(), "生活就像一盒巧克力。".into()]).unwrap().into()).into())),
+                        ("source_language".into(), TensorOrMisc::Tensor(Tensor::String(ndarray::ArrayD::from_shape_vec(ndarray::IxDyn(&[2]), vec!["Hindi".into(), "Chinese".into()]).unwrap().into()).into())),
+                        ("target_language".into(), TensorOrMisc::Tensor(Tensor::String(ndarray::ArrayD::from_shape_vec(ndarray::IxDyn(&[2]), vec!["French".into(), "English".into()]).unwrap().into()).into())),
+                    ].into(),
+                    sample_out: [
+                        ("output".into(), TensorOrMisc::Tensor(Tensor::String(ndarray::ArrayD::from_shape_vec(ndarray::IxDyn(&[2, 1]), vec!["La vie est comme une boîte de chocolat.".into(), "Life is like a box of chocolate.".into()]).unwrap().into()).into()))
+                    ].into(),
+                }
+            ]),
+            runner: RunnerInfo {
+                runner_name: "rust-bert".into(),
+                required_framework_version: semver::VersionReq::parse(">= 0.0.0").unwrap(),
+                runner_compat_version: None,
+                opts: None,
+            },
+            misc_files: None,
+        }).await.unwrap()
+    }
+}

--- a/source/carton-runner-rust-bert/tests/pack.rs
+++ b/source/carton-runner-rust-bert/tests/pack.rs
@@ -1,0 +1,92 @@
+use std::{collections::HashMap, path::PathBuf};
+
+use carton::{info::TensorOrMisc, types::LoadOpts};
+use carton_runner_packager::RunnerPackage;
+use tokio::process::Command;
+
+#[tokio::test]
+async fn test_pack() {
+    // Logging (for long running downloads)
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
+        .is_test(true)
+        .init();
+
+    // Get the path of the builder
+    let builder_path = PathBuf::from(env!("CARGO_BIN_EXE_build_rust_bert_releases"));
+
+    // Create a tempdir to store packaging artifacts
+    let tempdir = tempfile::tempdir().unwrap();
+    let tempdir_path = tempdir.path();
+
+    // Run the builder
+    let status = Command::new(builder_path)
+        .args(&["--output-path", tempdir_path.to_str().unwrap()])
+        .status()
+        .await
+        .unwrap();
+    assert!(status.success());
+
+    // Get a package
+    let package_config = std::fs::read_dir(&tempdir_path)
+        .unwrap()
+        .find_map(|item| {
+            if let Ok(item) = item {
+                if item.file_name().to_str().unwrap().ends_with(".json") {
+                    return Some(item);
+                }
+            }
+
+            None
+        })
+        .unwrap();
+
+    let package: RunnerPackage =
+        serde_json::from_slice(&std::fs::read(package_config.path()).unwrap()).unwrap();
+
+    // Get the zipfile path
+    let path = tempdir_path.join(format!("{}.zip", package.get_data_sha256()));
+    let download_info = package.get_download_info(path.to_str().unwrap().to_owned());
+
+    // Now install the runner we just packaged into a tempdir
+    let runner_dir = tempfile::tempdir().unwrap();
+    std::env::set_var("CARTON_RUNNER_DIR", runner_dir.path());
+    log::info!("About to install runner");
+    carton_runner_packager::install(download_info, true).await;
+    log::info!("Installed runner");
+
+    // Pack models
+    let m2m100_path = carton_runner_rust_bert::translate::pack::pack_m2m100().await;
+    log::info!("Packed m2m100 model: {m2m100_path:#?}");
+
+    let model = carton::Carton::load(
+        m2m100_path.to_str().unwrap().to_owned(),
+        LoadOpts {
+            visible_device: carton::types::Device::maybe_from_index(0),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    log::info!("Loaded model. Getting example inputs");
+
+    let ex = &model.get_info().info.examples.as_ref().unwrap()[0];
+    let mut tensors = HashMap::new();
+    for (k, v) in &ex.inputs {
+        if let TensorOrMisc::Tensor(t) = v {
+            let t = t.get().await.clone();
+            tensors.insert(k.clone(), t);
+        } else {
+            panic!("Expected tensor but got misc");
+        }
+    }
+
+    log::info!("running inference");
+    let out = model.infer_with_inputs(tensors).await.unwrap();
+    for (k, v) in out {
+        log::info!("{k}: {v:#?}");
+    }
+
+    // Delete the packed model
+    tokio::fs::remove_file(m2m100_path).await.unwrap();
+}

--- a/source/carton/Cargo.toml
+++ b/source/carton/Cargo.toml
@@ -48,7 +48,7 @@ lunchbox = { version = "0.1", features = ["serde"]}
 criterion = {version = "0.4", features = ["async_tokio", "html_reports"]}
 tokio = { version = "1", features = ["full", "tracing"] }
 console-subscriber = "0.1.8"
-escargot = "0.5.7"
+escargot = "0.5.8"
 
 [[bench]]
 name = "bench_noop_infer"

--- a/source/carton/src/runner_interface/storage.rs
+++ b/source/carton/src/runner_interface/storage.rs
@@ -3,6 +3,7 @@
 use crate::types::{TensorStorage, TypedStorage};
 use lunchbox::types::{MaybeSend, MaybeSync};
 
+#[derive(Debug)]
 pub struct RunnerStorage;
 
 impl TensorStorage for RunnerStorage {
@@ -13,6 +14,7 @@ impl TensorStorage for RunnerStorage {
     type TypedStringStorage = TypedRunnerStorage<String>;
 }
 
+#[derive(Debug)]
 pub enum TypedRunnerStorage<T> {
     V1(runner_interface_v1::types::TensorStorage<T>),
 }

--- a/source/carton/src/types.rs
+++ b/source/carton/src/types.rs
@@ -147,6 +147,7 @@ pub type CartonInfo<T> = crate::info::CartonInfo<T>;
 
 for_each_numeric_carton_type! {
     /// The core tensor type
+    #[derive(Debug)]
     pub enum Tensor<Storage> where Storage: TensorStorage {
         $($CartonType(Storage::TypedStorage::<$RustType>),)*
 
@@ -167,6 +168,19 @@ for_each_numeric_carton_type! {
         /// is the same:
         /// https://www.tensorflow.org/guide/ragged_tensor#what_you_can_store_in_a_ragged_tensor
         NestedTensor(Vec<Tensor<Storage>>)
+    }
+}
+
+for_each_carton_type! {
+    impl Clone for Tensor<GenericStorage> {
+        fn clone(&self) -> Self {
+            match self {
+                $(
+                    Self::$CartonType(item) => Self::$CartonType(item.clone()),
+                )*
+                Self::NestedTensor(item) => Self::NestedTensor(item.clone()),
+            }
+        }
     }
 }
 

--- a/source/fetch-deps/Cargo.toml
+++ b/source/fetch-deps/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "fetch-deps"
+version = "0.0.1"
+edition = "2021"
+
+[dependencies]
+tokio = { version = "1", features = ["full"] }
+carton-utils = { path = "../carton-utils" }
+tempfile = "3.3.0"

--- a/source/fetch-deps/src/lib.rs
+++ b/source/fetch-deps/src/lib.rs
@@ -1,0 +1,27 @@
+// x86 linux
+#[cfg(all(not(target_os = "macos"), target_arch = "x86_64"))]
+pub mod libtorch {
+    pub const URL: &str = "https://download.pytorch.org/libtorch/cu118/libtorch-cxx11-abi-shared-with-deps-2.0.1%2Bcu118.zip";
+    pub const SHA256: &str = "843ad19e769a189758fd6a21bfced9024494b52344f4bc4fb75f75d36e6ea0c7";
+}
+
+// aarch64 linux
+#[cfg(all(not(target_os = "macos"), target_arch = "aarch64"))]
+pub mod libtorch {
+    pub const URL: &str = "https://github.com/VivekPanyam/libtorch-prebuilts/releases/download/2.0.1/libtorch-aarch64-cxx11-abi-shared-with-deps-2.0.1-cpu.zip";
+    pub const SHA256: &str = "bff875b93ec7f5712bba4dd98a3a8b99ca814fdd575b1eb4afa33b0f1bd51fa2";
+}
+
+// x86 mac
+#[cfg(all(target_os = "macos", target_arch = "x86_64"))]
+pub mod libtorch {
+    pub const URL: &str = "https://download.pytorch.org/libtorch/cpu/libtorch-macos-2.0.1.zip";
+    pub const SHA256: &str = "002876b74d8432ee8ab9d0e710159353149d92ada73ef81844e81bccbfa52e95";
+}
+
+// aarch64 mac
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+pub mod libtorch {
+    pub const URL: &str = "https://github.com/VivekPanyam/libtorch-prebuilts/releases/download/2.0.1/libtorch-amd64-macos-2.0.1.zip";
+    pub const SHA256: &str = "ad304b78d24f7c52f7926b836d9aadee89d145039ff47c9b313d2d816028c05d";
+}

--- a/source/fetch-deps/src/main.rs
+++ b/source/fetch-deps/src/main.rs
@@ -1,0 +1,31 @@
+use std::path::PathBuf;
+
+#[tokio::main]
+pub async fn main() {
+    fetch_libtorch().await;
+}
+
+/// Fetch libtorch
+async fn fetch_libtorch() {
+    let libtorch_dir = PathBuf::from(env!("LIBTORCH"));
+
+    let url = fetch_deps::libtorch::URL;
+    let sha256 = fetch_deps::libtorch::SHA256;
+
+    if !libtorch_dir.exists() {
+        println!("Downloading libtorch to {libtorch_dir:#?} from {url} ...");
+        std::fs::create_dir_all(&libtorch_dir).unwrap();
+
+        let td = tempfile::tempdir().unwrap();
+        let download_path = td.path().join("download");
+
+        // Download the file
+        carton_utils::download::cached_download(url, sha256, &download_path, |_| {}, |_| {})
+            .await
+            .unwrap();
+
+        // Unpack it (the zip file contains a libtorch dir so we unpack in the parent dir)
+        carton_utils::archive::extract_zip(download_path.as_path(), libtorch_dir.parent().unwrap())
+            .await;
+    }
+}


### PR DESCRIPTION
This PR adds a runner that uses [`rust-bert`](https://github.com/guillaume-be/rust-bert).

It adds initial support for translation models along with a test that packs and runs a model. Other types of NLP models will be supported by future PRs.