### PR TITLE
Remove repo clone token from CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,7 +2,6 @@ only_if: $CIRRUS_TAG == '' && ($CIRRUS_PR != '' || $CIRRUS_BRANCH == 'main')
 
 env:
   CARGO_TERM_COLOR: always
-  CIRRUS_REPO_CLONE_TOKEN: ENCRYPTED[d6e35d6af0f64a5b9867662226058191c97bdccd3e4161873dfa8d309e273bdd5895848a663de57a27440188b98005b5]
 
 # linux_task:
 #   name: Native Build aarch64-unknown-linux-gnu
@@ -10,9 +9,6 @@ env:
 #     dockerfile: ci/ci.dockerfile
 #     cpu: 4
 #     memory: 16G
-#   submodules_script:
-#     # Init submodules
-#     - git -c url."https://x-access-token:${CIRRUS_REPO_CLONE_TOKEN}@github.com/".insteadOf="git@github.com:" submodule update --init --recursive
 #   target_cache:
 #     folder: target
 #     fingerprint_script:
@@ -27,9 +23,6 @@ macos_task:
   name: Native Build aarch64-apple-darwin
   macos_instance:
     image: ghcr.io/cirruslabs/macos-ventura-xcode:14.2
-  submodules_script:
-    # Init submodules
-    - git -c url."https://x-access-token:${CIRRUS_REPO_CLONE_TOKEN}@github.com/".insteadOf="git@github.com:" submodule update --init --recursive
   symlink_xcode_script:
     - ln -s /Applications/Xcode-14.2.0.app /Applications/Xcode.app
     - ls -alh /Applications/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.ZIPFS_READ }}
-          submodules: recursive
       - run: cargo fmt --check
   cargo-deny:
     name: cargo-deny
@@ -26,9 +23,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.ZIPFS_READ }}
-          submodules: recursive
       - uses: EmbarkStudios/cargo-deny-action@v1
         with:
           command: check bans licenses sources
@@ -50,9 +44,6 @@ jobs:
   #   steps:
   #     - name: Checkout
   #       uses: actions/checkout@v3
-  #       with:
-  #         token: ${{ secrets.ZIPFS_READ }}
-  #         submodules: recursive
   #     - run: rustup default stable
   #     - uses: Swatinem/rust-cache@v2
   #     - run: pip3 install toml maturin==0.14.13
@@ -69,9 +60,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.ZIPFS_READ }}
-          submodules: recursive
       - run: rustup target add wasm32-wasi
       - run: cargo build -p carton --verbose --target wasm32-wasi
   build_wasm:
@@ -80,9 +68,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.ZIPFS_READ }}
-          submodules: recursive
       - run: rustup target add wasm32-unknown-unknown
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,9 +27,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.ZIPFS_READ }}
-          submodules: recursive
       - run: rustup default stable
       - uses: Swatinem/rust-cache@v2
       - run: pip3 install toml maturin==0.14.13
@@ -50,9 +47,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.ZIPFS_READ }}
-          submodules: recursive
       - run: pip3 install gql[requests]
       - name: Wait for Cirrus CI builds to finish
         run: python3 ci/trigger_cirrus_build.py
@@ -76,9 +70,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.ZIPFS_READ }}
-          submodules: recursive
       - run: mkdir /tmp/artifacts
       - uses: actions/download-artifact@v3
         with:

--- a/ci/trigger_cirrus_build.py
+++ b/ci/trigger_cirrus_build.py
@@ -57,7 +57,6 @@ query = gql(
 CIRRUS_BUILD_CONFIG = """
 env:
   CARGO_TERM_COLOR: always
-  CIRRUS_REPO_CLONE_TOKEN: ENCRYPTED[d6e35d6af0f64a5b9867662226058191c97bdccd3e4161873dfa8d309e273bdd5895848a663de57a27440188b98005b5]
 
 # Nightly release builds
 # nightly_linux_task:
@@ -67,9 +66,6 @@ env:
 #     dockerfile: ci/ci.dockerfile
 #     cpu: 4
 #     memory: 16G
-#   submodules_script:
-#     # Init submodules
-#     - git -c url."https://x-access-token:${CIRRUS_REPO_CLONE_TOKEN}@github.com/".insteadOf="git@github.com:" submodule update --init --recursive
 #   target_cache:
 #     folder: target
 #     fingerprint_script:
@@ -90,9 +86,6 @@ nightly_macos_task:
   alias: nightly_macos
   macos_instance:
     image: ghcr.io/cirruslabs/macos-ventura-xcode:14.2
-  submodules_script:
-    # Init submodules
-    - git -c url."https://x-access-token:${CIRRUS_REPO_CLONE_TOKEN}@github.com/".insteadOf="git@github.com:" submodule update --init --recursive
   symlink_xcode_script:
     - ln -s /Applications/Xcode-14.2.0.app /Applications/Xcode.app
     - ls -alh /Applications/


### PR DESCRIPTION
Now that ZipFS is public (and no longer a submodule pointing to a private repo), we don't need a clone token