### PR TITLE
Move nightly Linux builds to Buildkite

### DIFF
--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -1,0 +1,27 @@
+# Nightly Buildkite builds that are triggered by a GH actions job
+steps:
+  - name: "Native Build x86_64-unknown-linux-gnu"
+    agents:
+      queue: default
+    command: "python3 ci/build.py --release --target x86_64-unknown-linux-gnu --nightly --runner_release_dir target/runner_releases"
+    artifact_paths:
+      - "target/cargo-timings/*"
+      - "target/wheels/*"
+      - "target/runner_releases/*"
+    plugins:
+      - docker-compose#v3.7.0:
+          run: x86_64
+          config: ci/buildkite_compose.yml
+
+  - name: "Native Build aarch64-unknown-linux-gnu"
+    agents:
+      queue: arm64
+    command: "python3 ci/build.py --release --target aarch64-unknown-linux-gnu --nightly --runner_release_dir target/runner_releases"
+    artifact_paths:
+      - "target/cargo-timings/*"
+      - "target/wheels/*"
+      - "target/runner_releases/*"
+    plugins:
+      - docker-compose#v3.7.0:
+          run: arm64
+          config: ci/buildkite_compose.yml

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,40 +9,40 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  nightly_release_native:
-    name: Native Build ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    container:
-      # TODO: only on linux
-      image: vpanyam/manylinux_2_28-rust-python310:x86_64
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-          # For now, don't run macos builds during nightly builds.
-          # TODO: reenable this when the repo is public
-          # - os: macos-latest
-          #   target: x86_64-apple-darwin
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - run: rustup default stable
-      - uses: Swatinem/rust-cache@v2
-      - run: pip3 install toml maturin==0.14.13
-      - run: python3 ci/build.py --target ${{ matrix.target }} --release --nightly --runner_release_dir /tmp/runner_releases
-      - name: Upload runners
-        uses: actions/upload-artifact@v3
-        with:
-          name: runners-${{ matrix.target }}
-          path: /tmp/runner_releases
-      - name: Upload python wheels
-        uses: actions/upload-artifact@v3
-        with:
-          name: py-wheels-${{ matrix.target }}
-          path: target/wheels/
-  nightly_release_aarch64:
-    name: "Native Build aarch64"
+  # nightly_release_native:
+  #   name: Native Build ${{ matrix.os }}
+  #   runs-on: ${{ matrix.os }}
+  #   container:
+  #     # TODO: only on linux
+  #     image: vpanyam/manylinux_2_28-rust-python310:x86_64
+  #   strategy:
+  #     matrix:
+  #       include:
+  #         - os: ubuntu-latest
+  #           target: x86_64-unknown-linux-gnu
+  #         # For now, don't run macos builds during nightly builds.
+  #         # TODO: reenable this when the repo is public
+  #         # - os: macos-latest
+  #         #   target: x86_64-apple-darwin
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #     - run: rustup default stable
+  #     - uses: Swatinem/rust-cache@v2
+  #     - run: pip3 install toml maturin==0.14.13
+  #     - run: python3 ci/build.py --target ${{ matrix.target }} --release --nightly --runner_release_dir /tmp/runner_releases
+  #     - name: Upload runners
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         name: runners-${{ matrix.target }}
+  #         path: /tmp/runner_releases
+  #     - name: Upload python wheels
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         name: py-wheels-${{ matrix.target }}
+  #         path: target/wheels/
+  nightly_release_mac_aarch64:
+    name: "Native Build macOS aarch64"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -55,17 +55,38 @@ jobs:
       - name: Upload runners
         uses: actions/upload-artifact@v3
         with:
-          name: runners-aarch64
+          name: runners-macos-aarch64
           path: /tmp/runner_releases
       - name: Upload python wheels
         uses: actions/upload-artifact@v3
         with:
-          name: py-wheels-aarch64
+          name: py-wheels-macos-aarch64
+          path: /tmp/target/wheels/
+  nightly_release_buildkite:
+    name: "Native Builds Linux (x86_64 and aarch64)"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - run: pip3 install requests
+      - name: Wait for Buildkite builds to finish
+        run: python3 ci/trigger_buildkite_build.py
+        env:
+          BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
+      - name: Upload runners
+        uses: actions/upload-artifact@v3
+        with:
+          name: runners-linux
+          path: /tmp/target/runner_releases
+      - name: Upload python wheels
+        uses: actions/upload-artifact@v3
+        with:
+          name: py-wheels-linux
           path: /tmp/target/wheels/
 
   upload_nightly_builds:
     name: "Upload nightly builds"
-    needs: [nightly_release_native, nightly_release_aarch64]
+    needs: [nightly_release_mac_aarch64, nightly_release_buildkite]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/ci/trigger_buildkite_build.py
+++ b/ci/trigger_buildkite_build.py
@@ -1,0 +1,78 @@
+# This script triggers a buildkite build for the current SHA and branch, waits for it to complete, and then
+# downloads artifacts. It looks at GITHUB_* env vars and is intended to be run from github actions.
+#
+# To use, make sure requests is installed (pip3 install requests)
+import os
+import requests
+import time
+
+
+BUILDKITE_TOKEN = os.getenv("BUILDKITE_TOKEN")
+if BUILDKITE_TOKEN is None:
+    raise ValueError("Expected BUILDKITE_TOKEN env var to be set")
+
+GITHUB_SHA = os.getenv("GITHUB_SHA")
+GITHUB_REF_TYPE = os.getenv("GITHUB_REF_TYPE")
+
+if GITHUB_REF_TYPE != "branch":
+    raise ValueError("Expected GITHUB_REF_TYPE to be 'branch'")
+
+GITHUB_BRANCH = os.getenv("GITHUB_REF_NAME")
+
+# Trigger a build
+
+res = requests.post("https://api.buildkite.com/v2/organizations/carton/pipelines/nightly/builds", headers={"Authorization": f"Bearer {BUILDKITE_TOKEN}"}, json={
+    "commit": GITHUB_SHA,
+    "branch": GITHUB_BRANCH,
+    "message": "Nightly build",
+})
+
+data = res.json()
+build_url = data["url"]
+build_number = data["number"]
+
+print(f"Created build {data['web_url']}")
+
+while True:
+    print("Waiting for build to complete...")
+
+    # Get the build status
+    data = requests.get(build_url, headers={"Authorization": f"Bearer {BUILDKITE_TOKEN}"}).json()
+    state = data["state"]
+
+    if state == "passed":
+        break
+
+    # States that are okay, but we need to keep checking
+    if state in ["creating", "scheduled", "running"]:
+        # Sleep for a bit before rechecking
+        time.sleep(10.0)
+    else:
+        raise ValueError(f"The build failed with status: {state}")
+
+print("Build complete! Getting artifacts...")
+
+fetch_url = f"https://api.buildkite.com/v2/organizations/carton/pipelines/nightly/builds/{build_number}/artifacts"
+while fetch_url is not None:
+    res = requests.get(fetch_url, headers={"Authorization": f"Bearer {BUILDKITE_TOKEN}"})
+
+    # Get the next url if any
+    if 'next' in res.links:
+        fetch_url = res.links['next']['url']
+    else:
+        fetch_url = None
+
+    artifacts = res.json()
+    for artifact in artifacts:
+        download_url = artifact["download_url"]
+        dirname = artifact["dirname"]
+        filename = artifact["filename"]
+        target_dir = os.path.join("/tmp", dirname)
+        os.makedirs(target_dir, exist_ok=True)
+        target_path = os.path.join(target_dir, filename)
+
+        print(f"Downloading {filename} to {target_path} ...")
+
+        res = requests.get(download_url, headers={"Authorization": f"Bearer {BUILDKITE_TOKEN}"})
+        with open(target_path, "wb") as f:
+            f.write(res.content)

--- a/source/carton-runner-packager/src/bin/ci_upload_releases.rs
+++ b/source/carton-runner-packager/src/bin/ci_upload_releases.rs
@@ -47,7 +47,7 @@ async fn main() {
 
     // Decode the runners file
     let contents = base64::engine::general_purpose::STANDARD
-        .decode(github_response.content.trim())
+        .decode(github_response.content.trim().replace("\n", ""))
         .unwrap();
     let mut runners: Vec<DownloadInfo> = serde_json::from_slice(&contents).unwrap();
 


### PR DESCRIPTION
This PR moves Linux nightly builds to Buildkite.

The way nightly builds now work is as follows:
- A nightly build is triggered on GH actions (either manually or via cron)
- One GH actions job spins up to trigger and wait for a Cirrus CI build for aarch64 macOS
- One GH actions job spins up to trigger and wait for a Buildkite build for x86_64 and aarch64 Linux
- Once both are done, they download artifacts and a final GH actions job runs that uploads the packages to storage and updates the runner index

*Note: cron based nightly builds are currently disabled while the project is private; "nightly" builds can be manually triggered as needed.*

### Test plan

Manual triggering and validation of the nightly pipeline. 