### PR TITLE
Restructure logging code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
+
+[[package]]
 name = "async-compression"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,6 +414,7 @@ dependencies = [
  "numpy",
  "pyo3",
  "pyo3-asyncio",
+ "pyo3-log",
  "semver 1.0.16",
  "target-lexicon",
  "tokio",
@@ -451,7 +458,6 @@ dependencies = [
  "clap 4.1.1",
  "criterion",
  "dashmap",
- "env_logger",
  "js-sys",
  "libc",
  "log",
@@ -1702,6 +1708,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
+ "serde",
 ]
 
 [[package]]
@@ -2275,6 +2282,17 @@ checksum = "839526a5c07a17ff44823679b68add4a58004de00512a95b6c1c98a6dcac0ee5"
 dependencies = [
  "libc",
  "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-log"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f47b0777feb17f61eea78667d61103758b243a871edc09a7786500a50467b605"
+dependencies = [
+ "arc-swap",
+ "log",
+ "pyo3",
 ]
 
 [[package]]

--- a/source/carton-bindings-py/Cargo.toml
+++ b/source/carton-bindings-py/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib"]
 [dependencies]
 pyo3 = { version = "0.18", features = ["abi3-py37"]}
 pyo3-asyncio = { version = "0.18", features = ["attributes", "tokio-runtime"] }
+pyo3-log = "0.8.3"
 carton-core = { package = "carton", path = "../carton" }
 numpy = "0.18"
 ndarray = { version = "0.15" }

--- a/source/carton-runner-interface/Cargo.toml
+++ b/source/carton-runner-interface/Cargo.toml
@@ -17,8 +17,7 @@ lunchbox = { version = "0.1", features = ["serde"], default-features = false }
 semver = {version = "1.0.16", features = ["serde"]}
 once_cell = "1.17.0"
 serde_bytes = "0.11"
-log = "0.4"
-env_logger = "0.9"
+log = { version = "0.4", features = ["serde"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 tracing-chrome = "0.7"

--- a/source/carton-runner-interface/src/client.rs
+++ b/source/carton-runner-interface/src/client.rs
@@ -49,9 +49,14 @@ impl Client {
         // Handle rpc responses
         tokio::spawn(async move {
             while let Some(response) = recv.recv().await {
-                // Send the response to the callback
-                let callback = inflight_clone.remove(&response.id).unwrap().1;
-                callback.send(response).unwrap();
+                // Handle logging
+                if let RPCResponseData::LogMessage { record } = response.data {
+                    record.do_log();
+                } else {
+                    // Send the response to the callback
+                    let callback = inflight_clone.remove(&response.id).unwrap().1;
+                    callback.send(response).unwrap();
+                }
             }
         });
 


### PR DESCRIPTION
This PR modifies logging in the runners to pass all log messages to the main process. It also updates the python bindings to use `pyo3-log` to integrate with python logging.

This lets us send all logs from carton to python logging (rather than separately logging from runner processes).