### PR TITLE
Route logging to `console.log` for WASM builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,7 +427,9 @@ dependencies = [
  "async-trait",
  "carton",
  "console_error_panic_hook",
+ "console_log",
  "js-sys",
+ "log",
  "semver 1.0.16",
  "serde",
  "serde-wasm-bindgen",
@@ -810,6 +812,17 @@ checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
 dependencies = [
  "cfg-if",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "console_log"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be8aed40e4edbf4d3b4431ab260b63fdc40f5780a4766824329ea0f1eefe3c0f"
+dependencies = [
+ "log",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]

--- a/source/carton-bindings-wasm/Cargo.toml
+++ b/source/carton-bindings-wasm/Cargo.toml
@@ -24,3 +24,5 @@ wasm-streams = "0.3.0"
 tokio-util = {version = "0.7", features = ["compat"]}
 js-sys = "0.3.60"
 console_error_panic_hook = { version = "0.1.1", optional = true }
+console_log = { version = "1", features = ["color"] }
+log = "0.4"

--- a/source/carton-bindings-wasm/src/lib.rs
+++ b/source/carton-bindings-wasm/src/lib.rs
@@ -30,7 +30,7 @@ impl From<carton_core::error::CartonError> for CartonError {
 #[wasm_bindgen]
 pub async fn get_model_info(url: String) -> Result<CartonInfo, CartonError> {
     // TODO: we want to call this from all possible entrypoints (including registration code)
-    utils::set_panic_hook();
+    utils::init_logging();
     let info = carton_core::Carton::get_model_info(url).await;
 
     info.map(|v| v.into()).map_err(|e| e.into())

--- a/source/carton-bindings-wasm/src/utils.rs
+++ b/source/carton-bindings-wasm/src/utils.rs
@@ -1,4 +1,6 @@
-pub fn set_panic_hook() {
+use std::sync::OnceLock;
+
+pub fn init_logging() {
     // When the `console_error_panic_hook` feature is enabled, we can call the
     // `set_panic_hook` function at least once during initialization, and then
     // we will get better error messages if our code ever panics.
@@ -7,4 +9,9 @@ pub fn set_panic_hook() {
     // https://github.com/rustwasm/console_error_panic_hook#readme
     #[cfg(feature = "console_error_panic_hook")]
     console_error_panic_hook::set_once();
+
+    // Init logging to trace
+    // TODO: change this to Info for release builds
+    static CELL: OnceLock<()> = OnceLock::new();
+    CELL.get_or_init(|| console_log::init_with_level(log::Level::Trace).unwrap());
 }

--- a/source/carton/src/http.rs
+++ b/source/carton/src/http.rs
@@ -258,7 +258,7 @@ async fn fetch_range(
     range_start: u64,
     num_bytes: u64,
 ) -> bytes::Bytes {
-    println!("Request: {} {}", range_start, num_bytes);
+    log::trace!("Request: {url} {range_start} {num_bytes}");
     let range_end = range_start + num_bytes - 1;
     let res = client
         .get(url)
@@ -285,7 +285,7 @@ type FetchReturnType = Box<dyn AsyncRead + Unpin + Send + Sync>;
 type FetchReturnType = Box<dyn AsyncRead + Unpin>;
 
 async fn fetch(client: &reqwest::Client, url: &str, range_start: u64) -> FetchReturnType {
-    println!("Request: {}", range_start);
+    log::trace!("Request: {url} {range_start}");
     let res = client
         .get(url)
         .header(reqwest::header::RANGE, format!("bytes={range_start}-"))


### PR DESCRIPTION
### Test plan

Tested locally to ensure that messages were correctly displayed