### PR TITLE
Allow passing custom options to the python runner

### DIFF
--- a/docs/website/pages/docs/packing/python.mdx
+++ b/docs/website/pages/docs/packing/python.mdx
@@ -39,7 +39,11 @@ class Model:
             "out": tensors["x"] * 2
         }
 
-def get_model():
+def get_model(an_example_custom_option: bool):
+    """
+    Your entrypoint function can also accept custom options as arguments.
+    See below for more details.
+    """
     return Model()
 ```
 
@@ -76,6 +80,10 @@ async def main():
 
             # The `get_model` function from above
             "entrypoint_fn": "get_model",
+
+            # A custom option specific to your model. This is passed to your
+            # entrypoint function without the `model.` prefix
+            "model.an_example_custom_option": False,
         }
     )
 
@@ -104,12 +112,16 @@ See https://docs.rs/semver/1.0.16/semver/enum.Op.html and https://docs.rs/semver
 
 ### `runner_opts`
 
-For python models, there are two options that can be specified here and both are required.
+For python models, there are two options that must be specified here.
 
 - `entrypoint_package`: The name of the python package that contains your entrypoint function, relative to the root of the code dir. <br/>Ex: `carton_entrypoint` for `carton_entrypoint.py` <br/>Ex: `some.sub.module` for `some/sub/module.py`
 - `entrypoint_fn`: The name of the entrypoint function.<br/>Ex: `get_model`
 
-The sample code above shows usage of all of these options.
+The sample code above shows usage of both of these options.
+
+You may also provide custom options specific to your model. These options must be prefixed with `model.` and are passed to your entrypoint function without the prefix.
+
+Valid types for options are numbers (integers and floats), strings, and booleans.
 
 ## Other options
 

--- a/source/carton-runner-py/tests/load_unpacked.rs
+++ b/source/carton-runner-py/tests/load_unpacked.rs
@@ -79,6 +79,14 @@ async fn test_pack_python_model() {
                         "entrypoint_fn".into(),
                         RunnerOpt::String("get_model".into()),
                     ),
+                    (
+                        "model.an_example_custom_option".into(),
+                        RunnerOpt::String("some_string_value".into()),
+                    ),
+                    (
+                        "model.another_example_custom_option".into(),
+                        RunnerOpt::Boolean(false),
+                    ),
                 ]
                 .into(),
             ),
@@ -116,12 +124,18 @@ class Model:
     def infer_with_tensors(self, tensors):
         pass
 
-def get_model():
+def get_model(an_example_custom_option, another_example_custom_option):
     print("Loaded python model!")
     assert os.path.islink("requirements.txt")
     expected_xgb_version = "1.7.3"
     if xgb.__version__ != expected_xgb_version:
         raise ValueError(f"Got an unexpected version of xgboost. Got {xgb.__version__} and expected {expected_xgb_version}")
+
+    if an_example_custom_option != "some_string_value":
+        raise ValueError("an_example_custom_option did not match the expected value")
+
+    if another_example_custom_option != False:
+        raise ValueError("another_example_custom_option did not match the expected value")
 
     return Model()
 "#,


### PR DESCRIPTION
This PR allows users to set custom model-specific runner options for Python models. Any options with the `model.` prefix are forwarded to the model's entrypoint function.

This PR also updates the packing docs to describe and show an example of this feature.

### Test plan

Added a test that verifies expected behavior.