### PR TITLE
Use `zip` instead of `async_zip` when packing models

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,7 +357,6 @@ name = "carton"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "async_zip",
  "bytes",
  "carton-macros",
  "carton-runner-interface",
@@ -389,6 +388,7 @@ dependencies = [
  "url",
  "uuid",
  "walkdir",
+ "zip",
  "zipfs",
 ]
 
@@ -518,7 +518,6 @@ dependencies = [
 name = "carton-runner-py"
 version = "0.0.1"
 dependencies = [
- "async_zip",
  "bytes",
  "bytesize",
  "carton",

--- a/source/carton-runner-py/Cargo.toml
+++ b/source/carton-runner-py/Cargo.toml
@@ -16,7 +16,6 @@ lazy_static = "1.4.0"
 reqwest = { version = "0.11", features = ["rustls-tls"], default-features = false }
 tempfile = "3.3.0"
 sha2 = "0.10.6"
-async_zip = {version = "0.0.11", features = ["full"]}
 path-clean = "0.1.0"
 toml = "0.5"
 serde = { version = "1.0", features = ["derive"] }

--- a/source/carton/Cargo.toml
+++ b/source/carton/Cargo.toml
@@ -27,7 +27,6 @@ runner_interface_v1 = { package = "carton-runner-interface", path = "../carton-r
 thiserror = "1"
 sha2 = "0.10.6"
 walkdir = "2.3.2"
-async_zip = {version = "0.0.11", features = ["chrono", "deflate", "zstd"]}
 path-clean = "0.1.0"
 pin-project = "1"
 tokio-util = {version = "0.7", features = ["compat"]}
@@ -41,6 +40,7 @@ dlopen_derive = "0.1"
 uuid = "1.3"
 lunchbox = { version = "0.1", features = ["serde", "localfs"]}
 carton-runner-packager = { path = "../carton-runner-packager" }
+zip = {version = "0.6", features = ["zstd"]}
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 lunchbox = { version = "0.1", features = ["serde"]}


### PR DESCRIPTION
The zip64 support in `async_zip` has a decent number of issues on both the read and write side (eg https://github.com/Majored/rs-async-zip/issues/105, https://github.com/Majored/rs-async-zip/issues/108) that cause invalid files when using large models.

The `zip` library is more mature than `async_zip` and has had zip64 support for longer. In local tests, the produced files are correct.

The lack of built-in async support is not an issue when we're packing a model so the change is relatively straightforward.

`async-zip` is still used when reading and loading models.

### Test plan

CI + local inspection of the created files