### PR TITLE
Update python documentation + change default device

### DIFF
--- a/docs/website/pages/docs/loading.mdx
+++ b/docs/website/pages/docs/loading.mdx
@@ -40,7 +40,10 @@ Allowed values:
  - A GPU index (e.g. `0`, `1`, etc.)
  - A GPU UUID (including the `GPU-` or `MIG-GPU-` prefix).<br/>See https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#env-vars for more details.
 
+The default is GPU 0 (or CPU if no GPUs are available).
+
 Note: a visible device does not necessarily mean that the model will use that device; it is up to the model to actually use it (e.g. by moving itself to GPU if it sees one available).
+Note: If a GPU index is specified, but no GPUs are available, Carton will print a warning and attempt to fallback to CPU
 
 ```python
 await carton.load(

--- a/docs/website/pages/docs/packing/python.mdx
+++ b/docs/website/pages/docs/packing/python.mdx
@@ -72,7 +72,7 @@ async def main():
         # Options for the python runner (including entrypoint info) go here
         runner_opts={
             # `carton_entrypoint.py` from above
-            "entrypoint": "carton_entrypoint",
+            "entrypoint_package": "carton_entrypoint",
 
             # The `get_model` function from above
             "entrypoint_fn": "get_model",
@@ -106,7 +106,7 @@ See https://docs.rs/semver/1.0.16/semver/enum.Op.html and https://docs.rs/semver
 
 For python models, there are two options that can be specified here and both are required.
 
-- `entrypoint`: The name of the python package that contains your entrypoint function, relative to the root of the code dir. <br/>Ex: `carton_entrypoint` for `carton_entrypoint.py` <br/>Ex: `some.sub.module` for `some/sub/module.py`
+- `entrypoint_package`: The name of the python package that contains your entrypoint function, relative to the root of the code dir. <br/>Ex: `carton_entrypoint` for `carton_entrypoint.py` <br/>Ex: `some.sub.module` for `some/sub/module.py`
 - `entrypoint_fn`: The name of the entrypoint function.<br/>Ex: `get_model`
 
 The sample code above shows usage of all of these options.

--- a/source/carton/src/types.rs
+++ b/source/carton/src/types.rs
@@ -39,9 +39,8 @@ pub struct LoadOpts {
 pub type RunnerOpt = crate::info::RunnerOpt;
 
 /// Supported device types
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 pub enum Device {
-    #[default]
     CPU,
     GPU {
         /// The UUID of the specified device
@@ -49,6 +48,19 @@ pub enum Device {
         /// See https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#env-vars
         uuid: Option<String>,
     },
+}
+
+/// Default to the first visible GPU (if any)
+impl Default for Device {
+    #[cfg(not(target_family = "wasm"))]
+    fn default() -> Self {
+        Device::maybe_from_index(0)
+    }
+
+    #[cfg(target_family = "wasm")]
+    fn default() -> Self {
+        Device::GPU { uuid: None }
+    }
 }
 
 impl Device {


### PR DESCRIPTION
This PR changes the default device from CPU to the first visible GPU (if any) and updates the documentation to match.

It also fixes a mistake in the python model packing documentation