### PR TITLE
Add the ability to specify linked files when packing

### DIFF
--- a/source/carton-bindings-py/python/cartonml/utils/hf.py
+++ b/source/carton-bindings-py/python/cartonml/utils/hf.py
@@ -1,0 +1,22 @@
+from collections import defaultdict
+from huggingface_hub import HfApi, hf_hub_url
+from typing import Dict, Optional
+
+def get_linked_files(repo_id: str, revision: Optional[str]) -> Dict[str, list[str]]:
+    """
+    Get a mapping of all the LFS files in a huggingface repo. Using this as part of packing can help create
+    smaller packed models and allow for more efficient caching.
+
+    This mapping can be passed into `carton.pack`
+    """
+    _api = HfApi()
+    repo_info = _api.repo_info(repo_id=repo_id, revision=revision, files_metadata=True)
+    commit_hash = repo_info.sha
+
+    lfs_mapping = defaultdict(list)
+    for item in repo_info.siblings:
+        file_path = item.rfilename
+        if item.lfs is not None:
+            lfs_mapping[item.lfs['sha256']].append(hf_hub_url(repo_id=repo_id, filename=file_path, revision=commit_hash))
+
+    return lfs_mapping

--- a/source/carton-bindings-py/src/lib.rs
+++ b/source/carton-bindings-py/src/lib.rs
@@ -133,6 +133,7 @@ fn load_unpacked(
     examples: Option<Vec<Example>>,
     misc_files: Option<HashMap<String, Vec<u8>>>,
     visible_device: Option<Device>,
+    linked_files: Option<HashMap<String, Vec<String>>>,
 ) -> PyResult<&PyAny> {
     maybe_init_logging();
     pyo3_asyncio::tokio::future_into_py(py, async move {
@@ -150,6 +151,7 @@ fn load_unpacked(
             self_tests,
             examples,
             misc_files,
+            linked_files,
         )?;
 
         // No need for overrides here
@@ -183,6 +185,7 @@ fn pack(
     self_tests: Option<Vec<SelfTest>>,
     examples: Option<Vec<Example>>,
     misc_files: Option<HashMap<String, Vec<u8>>>,
+    linked_files: Option<HashMap<String, Vec<String>>>,
 ) -> PyResult<&PyAny> {
     maybe_init_logging();
     pyo3_asyncio::tokio::future_into_py(py, async move {
@@ -200,6 +203,7 @@ fn pack(
             self_tests,
             examples,
             misc_files,
+            linked_files,
         )?;
 
         let out = carton_core::Carton::pack(path, opts)

--- a/source/carton-runner-py/tests/load_unpacked.rs
+++ b/source/carton-runner-py/tests/load_unpacked.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use carton::{
     info::RunnerInfo,
-    types::{CartonInfo, GenericStorage, LoadOpts, RunnerOpt},
+    types::{CartonInfo, GenericStorage, LoadOpts, PackOpts, RunnerOpt},
     Carton,
 };
 use carton_runner_packager::RunnerPackage;
@@ -56,7 +56,7 @@ async fn test_pack_python_model() {
     std::env::set_var("CARTON_RUNNER_DIR", runner_dir.path());
     carton_runner_packager::install(download_info, true).await;
 
-    let pack_opts: CartonInfo<GenericStorage> = CartonInfo {
+    let info: CartonInfo<GenericStorage> = CartonInfo {
         model_name: None,
         short_description: None,
         model_description: None,
@@ -119,7 +119,10 @@ def get_model():
     // Pack and load the model
     let _model = Carton::load_unpacked(
         model_dir.path().to_str().unwrap().to_owned(),
-        pack_opts,
+        PackOpts {
+            info,
+            linked_files: None,
+        },
         LoadOpts::default(),
     )
     .await

--- a/source/carton-runner-rust-bert/src/qa.rs
+++ b/source/carton-runner-rust-bert/src/qa.rs
@@ -130,7 +130,7 @@ pub mod pack {
 
     use carton::{
         info::{DataType, Example, RunnerInfo, Shape, TensorOrMisc, TensorSpec},
-        types::{GenericStorage, PackOpts, Tensor},
+        types::{CartonInfo, GenericStorage, PackOpts, Tensor},
     };
 
     use crate::{download_file, ModelConfig};
@@ -181,7 +181,7 @@ pub mod pack {
         res.2.unwrap();
 
         // Pack the model and return the path
-        carton::Carton::pack::<GenericStorage>(dir.path().to_str().unwrap().to_owned(), PackOpts {
+        let info = CartonInfo {
             model_name: Some("DistilBERT base cased distilled SQuAD".into()),
             short_description: Some("A DistilBERT model fine tuned for question answering.".into()),
             model_description: Some("See [here](https://huggingface.co/distilbert-base-cased-distilled-squad) for more details.".into()),
@@ -232,6 +232,16 @@ pub mod pack {
                 opts: None,
             },
             misc_files: None,
-        }).await.unwrap()
+        };
+
+        carton::Carton::pack::<GenericStorage>(
+            dir.path().to_str().unwrap().to_owned(),
+            PackOpts {
+                info,
+                linked_files: None,
+            },
+        )
+        .await
+        .unwrap()
     }
 }

--- a/source/carton-runner-rust-bert/src/summarize.rs
+++ b/source/carton-runner-rust-bert/src/summarize.rs
@@ -105,7 +105,7 @@ pub mod pack {
 
     use carton::{
         info::{DataType, Example, RunnerInfo, Shape, TensorOrMisc, TensorSpec},
-        types::{GenericStorage, PackOpts, Tensor},
+        types::{CartonInfo, GenericStorage, PackOpts, Tensor},
     };
 
     use crate::{download_file, ModelConfig};
@@ -181,7 +181,7 @@ Since Hubble’s discovery of Earendel, Webb has detected other very distant sta
         res.3.unwrap();
 
         // Pack the model and return the path
-        carton::Carton::pack::<GenericStorage>(dir.path().to_str().unwrap().to_owned(), PackOpts {
+        let info = CartonInfo {
             model_name: Some("BART".into()),
             short_description: Some("A BART model fine-tuned on CNN/Daily Mail to summarize text.".into()),
             model_description: Some("See [here](https://github.com/facebookresearch/fairseq/blob/main/examples/bart/README.md) for more details.".into()),
@@ -224,6 +224,16 @@ Since Hubble’s discovery of Earendel, Webb has detected other very distant sta
                 opts: None,
             },
             misc_files: None,
-        }).await.unwrap()
+        };
+
+        carton::Carton::pack::<GenericStorage>(
+            dir.path().to_str().unwrap().to_owned(),
+            PackOpts {
+                info,
+                linked_files: None,
+            },
+        )
+        .await
+        .unwrap()
     }
 }

--- a/source/carton-runner-rust-bert/src/text_generation.rs
+++ b/source/carton-runner-rust-bert/src/text_generation.rs
@@ -105,7 +105,7 @@ pub mod pack {
 
     use carton::{
         info::{DataType, Example, RunnerInfo, Shape, TensorOrMisc, TensorSpec},
-        types::{GenericStorage, PackOpts, Tensor},
+        types::{CartonInfo, GenericStorage, PackOpts, Tensor},
     };
 
     use crate::{download_file, ModelConfig};
@@ -161,7 +161,7 @@ pub mod pack {
         res.3.unwrap();
 
         // Pack the model and return the path
-        carton::Carton::pack::<GenericStorage>(dir.path().to_str().unwrap().to_owned(), PackOpts {
+        let info = CartonInfo {
             model_name: Some("GPT2 Medium".into()),
             short_description: Some("GPT2 Medium".into()),
             model_description: Some("See [here](https://github.com/openai/gpt-2) for more details.".into()),
@@ -204,6 +204,16 @@ pub mod pack {
                 opts: None,
             },
             misc_files: None,
-        }).await.unwrap()
+        };
+
+        carton::Carton::pack::<GenericStorage>(
+            dir.path().to_str().unwrap().to_owned(),
+            PackOpts {
+                info,
+                linked_files: None,
+            },
+        )
+        .await
+        .unwrap()
     }
 }

--- a/source/carton-runner-rust-bert/src/translate.rs
+++ b/source/carton-runner-rust-bert/src/translate.rs
@@ -140,7 +140,7 @@ pub mod pack {
 
     use carton::{
         info::{DataType, Dimension, Example, RunnerInfo, Shape, TensorOrMisc, TensorSpec},
-        types::{GenericStorage, PackOpts, Tensor},
+        types::{CartonInfo, GenericStorage, PackOpts, Tensor},
     };
     use rust_bert::{m2m_100::M2M100SourceLanguages, pipelines::translation::Language};
 
@@ -208,7 +208,7 @@ pub mod pack {
         res.3.unwrap();
 
         // Pack the model and return the path
-        carton::Carton::pack::<GenericStorage>(dir.path().to_str().unwrap().to_owned(), PackOpts {
+        let info = CartonInfo {
             model_name: Some("M2M100".into()),
             short_description: Some("M2M100 is a model that can translate directly between any pair of 100 languages.".into()),
             model_description: Some("See [here](https://about.fb.com/news/2020/10/first-multilingual-machine-translation-model/) for more details. M2M100 supports the following languages:\n".to_owned() + &languages.iter().map(|l| format!("- {}", serde_plain::to_string(l).unwrap())).collect::<Vec<_>>().join("\n")),
@@ -267,6 +267,16 @@ pub mod pack {
                 opts: None,
             },
             misc_files: None,
-        }).await.unwrap()
+        };
+
+        carton::Carton::pack::<GenericStorage>(
+            dir.path().to_str().unwrap().to_owned(),
+            PackOpts {
+                info,
+                linked_files: None,
+            },
+        )
+        .await
+        .unwrap()
     }
 }

--- a/source/carton/benches/bench_noop_infer.rs
+++ b/source/carton/benches/bench_noop_infer.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 use carton::{
     info::RunnerInfo,
-    types::{CartonInfo, GenericStorage, LoadOpts},
+    types::{CartonInfo, GenericStorage, LoadOpts, PackOpts},
     Carton,
 };
 use criterion::{criterion_group, criterion_main, Criterion};
@@ -55,7 +55,7 @@ platform = "{}"
     println!("Creating runtime");
     let runtime = tokio::runtime::Runtime::new().unwrap();
 
-    let pack_opts: CartonInfo<GenericStorage> = CartonInfo {
+    let info: CartonInfo<GenericStorage> = CartonInfo {
         model_name: None,
         short_description: None,
         model_description: None,
@@ -75,7 +75,14 @@ platform = "{}"
 
     let load_opts = LoadOpts::default();
     let carton = runtime
-        .block_on(Carton::load_unpacked("/tmp".into(), pack_opts, load_opts))
+        .block_on(Carton::load_unpacked(
+            "/tmp".into(),
+            PackOpts {
+                info,
+                linked_files: None,
+            },
+            load_opts,
+        ))
         .unwrap();
 
     c.bench_function("infer_noop", |b| {

--- a/source/carton/src/carton.rs
+++ b/source/carton/src/carton.rs
@@ -97,10 +97,11 @@ impl Carton {
 
         // Launch a runner
         let (runner, runner_info) =
-            discover_or_get_runner_and_launch(&opts, &crate::types::Device::CPU).await?;
+            discover_or_get_runner_and_launch(&opts.info, &crate::types::Device::CPU).await?;
 
         // Set the runner_compat_version if the user didn't
-        opts.runner
+        opts.info
+            .runner
             .runner_compat_version
             .get_or_insert(runner_info.runner_compat_version);
 
@@ -147,10 +148,11 @@ impl Carton {
 
         // Launch a runner
         let (runner, runner_info) =
-            discover_or_get_runner_and_launch(&pack_opts, &crate::types::Device::CPU).await?;
+            discover_or_get_runner_and_launch(&pack_opts.info, &crate::types::Device::CPU).await?;
 
         // Set the runner_compat_version if the user didn't
         pack_opts
+            .info
             .runner
             .runner_compat_version
             .get_or_insert(runner_info.runner_compat_version);
@@ -180,7 +182,7 @@ impl Carton {
 
         // Ask the runner to load the model it just packed
         let info_with_extras = CartonInfoWithExtras {
-            info: pack_opts,
+            info: pack_opts.info,
             manifest_sha256: None,
         };
 

--- a/source/carton/src/format/v1/links.rs
+++ b/source/carton/src/format/v1/links.rs
@@ -18,6 +18,16 @@ pub(crate) struct Links {
     pub(crate) urls: HashMap<String, Vec<String>>,
 }
 
+impl From<Vec<crate::info::LinkedFile>> for Links {
+    fn from(value: Vec<crate::info::LinkedFile>) -> Self {
+        let mut urls = HashMap::new();
+        for item in value {
+            urls.insert(item.sha256, item.urls);
+        }
+        Links { version: 1, urls }
+    }
+}
+
 /// Take a path to a packed carton along with a map from sha256 to urls and shrink the carton by storing
 /// URLs instead of the orig files when possible
 #[cfg(not(target_family = "wasm"))]

--- a/source/carton/src/info.rs
+++ b/source/carton/src/info.rs
@@ -18,6 +18,23 @@ use crate::{
     types::{Tensor, TensorStorage},
 };
 
+/// Options that can be specified when packing a model
+pub struct PackOpts<T>
+where
+    T: TensorStorage,
+{
+    pub info: CartonInfo<T>,
+
+    /// Any files to include in the carton as links (instead of the originals)
+    pub linked_files: Option<Vec<LinkedFile>>,
+}
+
+/// Info about files we want to include in the carton as links
+pub struct LinkedFile {
+    pub urls: Vec<String>,
+    pub sha256: String,
+}
+
 // Info about a carton
 pub struct CartonInfo<T>
 where

--- a/source/carton/src/types.rs
+++ b/source/carton/src/types.rs
@@ -152,7 +152,7 @@ impl<'de> Deserialize<'de> for Device {
 }
 
 /// Options that can be specified when packing a model
-pub type PackOpts<T> = CartonInfo<T>;
+pub type PackOpts<T> = crate::info::PackOpts<T>;
 
 pub type CartonInfo<T> = crate::info::CartonInfo<T>;
 

--- a/source/carton/tests/test_fetch_runner.rs
+++ b/source/carton/tests/test_fetch_runner.rs
@@ -2,7 +2,7 @@
 
 use carton::{
     info::RunnerInfo,
-    types::{GenericStorage, LoadOpts, PackOpts, RunnerOpt},
+    types::{CartonInfo, GenericStorage, LoadOpts, PackOpts, RunnerOpt},
     Carton,
 };
 use semver::VersionReq;
@@ -14,7 +14,7 @@ async fn main() {
     std::env::set_var("CARTON_RUNNER_DIR", runner_dir.path());
 
     // Pack a model that requires a specific version of python
-    let pack_opts: PackOpts<GenericStorage> = PackOpts {
+    let info: CartonInfo<GenericStorage> = CartonInfo {
         model_name: None,
         short_description: None,
         model_description: None,
@@ -76,7 +76,10 @@ def get_model():
     // Pack and load the model
     let _model = Carton::load_unpacked(
         model_dir.path().to_str().unwrap().to_owned(),
-        pack_opts,
+        PackOpts {
+            info,
+            linked_files: None,
+        },
         LoadOpts::default(),
     )
     .await


### PR DESCRIPTION
Instead of storing some large files directly in the output model, we can store links.

This is effectively `carton.shrink`, but as part of the packing process instead of as an extra step.

### Test plan

Tested locally with a large model to ensure packing, loading, and inference work as expected.