### PR TITLE
Refactor `HttpFS` to use `cached_download` under the hood

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,6 +389,7 @@ dependencies = [
  "carton-macros",
  "carton-runner-interface",
  "carton-runner-packager",
+ "carton-utils",
  "chrono",
  "console-subscriber",
  "criterion",
@@ -412,6 +413,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "toml",
  "url",
@@ -613,7 +615,9 @@ name = "carton-utils"
 version = "0.0.1"
 dependencies = [
  "async_zip 0.0.11",
+ "bytes",
  "flate2",
+ "futures",
  "infer",
  "lazy_static",
  "libc",
@@ -628,6 +632,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-util",
  "toml",
 ]
 

--- a/source/carton-runner-packager/src/lib.rs
+++ b/source/carton-runner-packager/src/lib.rs
@@ -71,7 +71,7 @@ pub async fn install(info: DownloadInfo, allow_local_files: bool) {
     let runner_dir = runner_base_dir.join(&info.id);
 
     // Extract into a temp dir and then move to the actual location
-    with_atomic_extraction(&runner_dir, |runner_dir| async move {
+    with_atomic_extraction(&runner_dir, (), |runner_dir, _| async move {
         let mut handles = Vec::new();
         for file in info.download_info {
             // If url is a local file, make sure allow_local_files is true
@@ -94,7 +94,7 @@ pub async fn install(info: DownloadInfo, allow_local_files: bool) {
                 let download_path = if is_file_path(&file.url) {
                     Path::new(&file.url)
                 } else {
-                    cached_download(&file.url, &file.sha256, &download_path, |_| {}, |_| {})
+                    cached_download(&file.url, &file.sha256, Some(&download_path), None, |_| {}, |_| {})
                         .await
                         .unwrap();
 

--- a/source/carton-runner-py/src/wheel.rs
+++ b/source/carton-runner-py/src/wheel.rs
@@ -51,7 +51,8 @@ pub async fn install_wheel(url: &str, sha256: &str) -> PathBuf {
     uncached_download(
         url,
         sha256,
-        &download_path,
+        Some(&download_path),
+        None,
         |total| {
             if let Some(size) = total {
                 sl.set_total(Some(bytesize::ByteSize(size)));
@@ -72,7 +73,10 @@ pub async fn install_wheel(url: &str, sha256: &str) -> PathBuf {
         .without_progress();
 
     // Unzip
-    with_atomic_extraction(&target_dir, |out_dir| extract_zip(download_path, out_dir)).await;
+    with_atomic_extraction(&target_dir, (), |out_dir, _| {
+        extract_zip(download_path, out_dir)
+    })
+    .await;
 
     sl.done();
 

--- a/source/carton-runner-rust-bert/src/lib.rs
+++ b/source/carton-runner-rust-bert/src/lib.rs
@@ -84,7 +84,8 @@ pub(crate) async fn download_file<P: AsRef<std::path::Path>>(
     let out = carton_utils::download::cached_download(
         url,
         sha256,
-        download_path,
+        Some(download_path),
+        None,
         |total| {
             if let Some(size) = total {
                 sl.set_total(Some(bytesize::ByteSize(size)));

--- a/source/carton-utils/Cargo.toml
+++ b/source/carton-utils/Cargo.toml
@@ -22,3 +22,6 @@ toml = "0.5"
 serde = { version = "1.0", features = ["derive"] }
 shellexpand = "3.0.0"
 serde_json = "1"
+bytes = "1.3.0"
+tokio-util = {version = "0.7", features = ["io"]}
+futures = "0.3"

--- a/source/carton-utils/src/archive.rs
+++ b/source/carton-utils/src/archive.rs
@@ -148,9 +148,9 @@ pub async fn extract(archive: &Path, out_dir: &Path) {
 /// This temporary directory is created in `target_dir.parent()` (with a name that starts with `.tmp`). This is necessary because
 /// we need to ensure that the temp dir and the target are on the same device to avoid EXDEV errors when renaming.
 /// Note: if `target_dir` exists, this function doesn't do anything
-pub async fn with_atomic_extraction<F, Fut>(target_dir: &Path, do_extract: F)
+pub async fn with_atomic_extraction<F, A, Fut>(target_dir: &Path, args: A, do_extract: F)
 where
-    F: FnOnce(PathBuf) -> Fut,
+    F: FnOnce(PathBuf, A) -> Fut,
     Fut: Future<Output = ()>,
 {
     if target_dir.exists() {
@@ -167,7 +167,7 @@ where
     let extraction_dir = tempdir.path().join("extraction");
 
     // Extract
-    do_extract(extraction_dir.clone()).await;
+    do_extract(extraction_dir.clone(), args).await;
 
     // Move to the target directory. This should be atomic so it won't break anything
     // if multiple installs happen at the same time.

--- a/source/carton-utils/src/download.rs
+++ b/source/carton-utils/src/download.rs
@@ -1,7 +1,10 @@
+use futures::StreamExt;
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::path::Path;
+use tokio::sync::mpsc;
+use tokio_util::io::ReaderStream;
 
 use crate::{
     archive::with_atomic_extraction,
@@ -10,33 +13,60 @@ use crate::{
 };
 
 lazy_static! {
-    static ref CLIENT: reqwest::Client = reqwest::Client::new();
+    // TODO: for some reason, if we allow HTTP2, requests hang when making
+    // multiple parallel requests (e.g. when loading a model)
+    // This is likely a bug within reqwest or something it uses under the hood
+    static ref CLIENT: reqwest::Client = reqwest::ClientBuilder::new()
+        .http1_only()
+        .use_rustls_tls()
+        .build()
+        .unwrap();
 }
 
 /// Download a file with progress updates
+/// Either download to a file or get a stream of chunks as the file is being downloaded (or both)
 pub async fn uncached_download<P: AsRef<Path>>(
     url: &str,
     sha256: &str,
-    download_path: P,
+    download_path: Option<P>,
+    chunk_stream: Option<mpsc::Sender<bytes::Bytes>>,
     mut on_content_len: impl FnMut(/* total */ Option<u64>),
     mut progress_update: impl FnMut(/* downloaded */ u64),
 ) -> Result<()> {
-    // Create the file
-    let mut outfile = tokio::fs::File::create(&download_path).await.unwrap();
+    // Create the file if necessary (can't use map because of the await)
+    let mut outfile = match download_path {
+        Some(download_path) => Some(tokio::fs::File::create(download_path).await.unwrap()),
+        None => None,
+    };
 
     // Download and copy to the target file while computing the sha256
     let mut hasher = Sha256::new();
-    let mut res = CLIENT.get(url).send().await.unwrap();
+    let mut res = CLIENT.get(url).send().await?;
+
+    if !res.status().is_success() {
+        // TODO: return an error instead of panic
+        panic!("Error fetching URL {}: {}", url, res.status());
+    }
 
     on_content_len(res.content_length());
     let mut downloaded = 0;
 
-    while let Some(chunk) = res.chunk().await.unwrap() {
-        // TODO: see if we should offload this to a blocking thread
-        hasher.update(&chunk);
-        tokio::io::copy(&mut chunk.as_ref(), &mut outfile)
-            .await
-            .unwrap();
+    while let Some(chunk) = res.chunk().await? {
+        // Compute hash in a blocking task
+        let b = chunk.clone();
+        let jh1 = tokio::task::spawn_blocking(move || hasher.chain_update(&b));
+
+        // Send the chunk out on the stream if we have one
+        if let Some(cs) = chunk_stream.as_ref() {
+            cs.send(chunk.clone()).await.unwrap();
+        }
+
+        // Copy to disk if we need to
+        if let Some(outfile) = outfile.as_mut() {
+            tokio::io::copy(&mut chunk.as_ref(), outfile).await.unwrap();
+        }
+
+        hasher = jh1.await.unwrap();
         downloaded += chunk.len() as u64;
         progress_update(downloaded);
     }
@@ -58,10 +88,13 @@ struct InfoJson {
     url: String,
 }
 
+/// Download a file with progress updates
+/// Either download to a file or get a stream of chunks as the file is being downloaded (or both)
 pub async fn cached_download<P: AsRef<Path>>(
     url: &str,
     sha256: &str,
-    download_path: P,
+    download_path: Option<P>,
+    mut chunk_stream: Option<mpsc::Sender<bytes::Bytes>>,
     on_content_len: impl FnMut(/* total */ Option<u64>),
     progress_update: impl FnMut(/* downloaded */ u64),
 ) -> Result<()> {
@@ -71,34 +104,54 @@ pub async fn cached_download<P: AsRef<Path>>(
 
     // Download if necessary
     // This is a noop if the target exists already
-    with_atomic_extraction(&files_cache_dir.join(sha256), |download_dir| async move {
-        // Create the download dir
-        tokio::fs::create_dir(&download_dir).await.unwrap();
+    with_atomic_extraction(
+        &files_cache_dir.join(sha256),
+        &mut chunk_stream,
+        |download_dir, chunk_stream| async move {
+            // Create the download dir
+            tokio::fs::create_dir(&download_dir).await.unwrap();
 
-        // Download
-        uncached_download(
-            url,
-            sha256,
-            download_dir.join("file"),
-            on_content_len,
-            progress_update,
-        )
-        .await
-        .unwrap();
-
-        // Write the info.json file
-        let info = InfoJson {
-            url: url.to_owned(),
-        };
-        let serialized = serde_json::to_string_pretty(&info).unwrap();
-        tokio::fs::write(download_dir.join("info.json"), serialized)
+            // Download
+            uncached_download(
+                url,
+                sha256,
+                Some(download_dir.join("file")),
+                chunk_stream.take(),
+                on_content_len,
+                progress_update,
+            )
             .await
             .unwrap();
-    })
+
+            // Write the info.json file
+            let info = InfoJson {
+                url: url.to_owned(),
+            };
+            let serialized = serde_json::to_string_pretty(&info).unwrap();
+            tokio::fs::write(download_dir.join("info.json"), serialized)
+                .await
+                .unwrap();
+        },
+    )
     .await;
 
     // We now have the file in the cache.
+    // Copy it to our target if we have one
     let cached_path = files_cache_dir.join(sha256).join("file");
-    tokio::fs::copy(cached_path, download_path).await.unwrap();
+    if let Some(download_path) = download_path {
+        tokio::fs::copy(&cached_path, download_path).await.unwrap();
+    }
+
+    // TODO: we can do this and the above in parallel
+    // If we didn't download, we need to load the file and send chunks to the chunk stream
+    // We can check this by seeing if `chunk_stream` is None (because of the `take` in the closure above)
+    if let Some(chunk_stream) = chunk_stream {
+        let f = tokio::fs::File::open(cached_path).await.unwrap();
+        let mut stream = ReaderStream::with_capacity(f, 1_000_000);
+        while let Some(chunk) = stream.next().await {
+            chunk_stream.send(chunk.unwrap()).await.unwrap();
+        }
+    }
+
     Ok(())
 }

--- a/source/carton/Cargo.toml
+++ b/source/carton/Cargo.toml
@@ -34,6 +34,7 @@ futures = "0.3"
 dashmap = "5.4.0"
 log = "0.4"
 pathdiff = "0.2.1"
+tokio-stream = "0.1"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 dlopen = "0.1"
@@ -42,6 +43,7 @@ uuid = "1.3"
 lunchbox = { version = "0.1", features = ["serde", "localfs"]}
 carton-runner-packager = { path = "../carton-runner-packager" }
 zip = {version = "0.6", features = ["zstd"]}
+carton-utils = { path = "../carton-utils" }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 lunchbox = { version = "0.1", features = ["serde"]}

--- a/source/carton/src/load.rs
+++ b/source/carton/src/load.rs
@@ -156,7 +156,7 @@ where
                             path.into(),
                             FileInfo {
                                 url: url.clone(),
-                                _sha256: sha256.to_owned(),
+                                sha256: sha256.to_owned(),
                             },
                         ))
                     } else {

--- a/source/fetch-deps/src/main.rs
+++ b/source/fetch-deps/src/main.rs
@@ -20,9 +20,16 @@ async fn fetch_libtorch() {
         let download_path = td.path().join("download");
 
         // Download the file
-        carton_utils::download::cached_download(url, sha256, &download_path, |_| {}, |_| {})
-            .await
-            .unwrap();
+        carton_utils::download::cached_download(
+            url,
+            sha256,
+            Some(&download_path),
+            None,
+            |_| {},
+            |_| {},
+        )
+        .await
+        .unwrap();
 
         // Unpack it (the zip file contains a libtorch dir so we unpack in the parent dir)
         carton_utils::archive::extract_zip(download_path.as_path(), libtorch_dir.parent().unwrap())


### PR DESCRIPTION
This PR refactors `HttpFS` to use `cached_download` on non-wasm targets. This means that large files stored as links will be cached and can be loaded from disk instead of requiring a network fetch each time a model is loaded.

### Test plan

Tested locally with a large model (in both cached and uncached scenarios)