### PR TITLE
Upload nightly builds to PyPI and NPM

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -88,6 +88,7 @@ jobs:
     name: "Upload nightly builds"
     needs: [nightly_release_mac_aarch64, nightly_release_buildkite]
     runs-on: ubuntu-latest
+    environment: nightly
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -104,3 +105,36 @@ jobs:
           CARTON_NIGHTLY_S3_ENDPOINT: ${{ secrets.CARTON_NIGHTLY_S3_ENDPOINT }}
           CARTON_NIGHTLY_ACCESS_KEY_ID: ${{ secrets.CARTON_NIGHTLY_ACCESS_KEY_ID }}
           CARTON_NIGHTLY_SECRET_ACCESS_KEY: ${{ secrets.CARTON_NIGHTLY_SECRET_ACCESS_KEY }}
+      - name: Upload wheels to PyPi
+        run: >
+          pip3 install twine &&
+          twine upload /tmp/artifacts/py-wheels-linux/* /tmp/artifacts/py-wheels-macos-aarch64/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_NIGHTLY_TOKEN }}
+          TWINE_NON_INTERACTIVE: true
+  build_wasm:
+    name: WASM Build wasm32-unknown-unknown
+    runs-on: ubuntu-latest
+    environment: nightly
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - run: rustup target add wasm32-unknown-unknown
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm install -g wasm-pack yarn@1.22.19
+      - name: Update version
+        run: >
+          cd source/carton-bindings-wasm &&
+          cat package.json  | jq '.version += (now | strftime("-dev%Y%m%d"))' | tee package.json
+      - run: >
+          cd source/carton-bindings-wasm && ./build.sh &&
+          cd tests && yarn install && node basic.js
+      - name: Publish to NPM
+        run: >
+          cd source/carton-bindings-wasm/dist && npm publish --tag next
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/ci/build.py
+++ b/ci/build.py
@@ -35,6 +35,13 @@ def update_version_numbers():
     with open(bindings_config, 'w') as f:
         toml.dump(data, f)
 
+    # Update the python package name
+    package_config = "source/carton-bindings-py/pyproject.toml"
+    data = toml.load(package_config)
+    data["project"]["name"] = "cartonml-nightly"
+    with open(package_config, 'w') as f:
+        toml.dump(data, f)
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(prog = 'Carton CI Build Script')
     parser.add_argument("-t", "--target", required=True, help="The target triple to build against")

--- a/source/carton-bindings-py/pyproject.toml
+++ b/source/carton-bindings-py/pyproject.toml
@@ -1,6 +1,10 @@
 [project]
 name = "cartonml"
 
+dependencies = [
+    "numpy >= 1.16.0"
+]
+
 [build-system]
 requires = ["maturin>=0.14,<0.15"]
 build-backend = "maturin"

--- a/source/carton-bindings-wasm/build.sh
+++ b/source/carton-bindings-wasm/build.sh
@@ -4,3 +4,5 @@ mkdir -p dist
 wasm-pack build --target browser --out-dir dist/web --out-name index --release
 wasm-pack build --target nodejs --out-dir dist/node --out-name index --release
 cp package.json dist
+rm dist/web/.gitignore
+rm dist/node/.gitignore


### PR DESCRIPTION
This PR modifies the nightly CI pipeline to upload packages to `cartonml-nightly` on PyPI and `@cartonml/wasm` on NPM

### Test plan

Manually triggered the workflow and verified that it publishes packages correctly.