### PR TITLE
Correctly handle Lunchbox symlink paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1760,8 +1760,7 @@ dependencies = [
 [[package]]
 name = "lunchbox"
 version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfcd18b5c3be722c8d3f05b465d7b92eb98d944ac6579649193194f49b2ee01"
+source = "git+https://github.com/VivekPanyam/lunchbox.git?branch=main#375d35f887bc2ab86af25e9228bcb04bd8772310"
 dependencies = [
  "async-trait",
  "path-clean",
@@ -3900,7 +3899,7 @@ dependencies = [
 [[package]]
 name = "zipfs"
 version = "0.0.1"
-source = "git+https://github.com/VivekPanyam/ZipFS.git?branch=update_async_zip#0060946acaf34f5f313f7ac9ad701b3e3598c57d"
+source = "git+https://github.com/VivekPanyam/ZipFS.git?branch=update_async_zip#e8da730ee481c982bc33d1ac20337ed9cbaaf4a3"
 dependencies = [
  "async-trait",
  "async_zip 0.0.15",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,4 @@ debug = true
 # Temporary patch while we're waiting for an upstream merge + release in async_zip
 zipfs = { git = "https://github.com/VivekPanyam/ZipFS.git", branch = "update_async_zip" }
 async_zip = { git = "https://github.com/VivekPanyam/rs-async-zip.git", branch = "fix_zip64" }
+lunchbox = { git = "https://github.com/VivekPanyam/lunchbox.git", branch = "main" }

--- a/source/carton-runner-py/src/loader.rs
+++ b/source/carton-runner-py/src/loader.rs
@@ -130,10 +130,13 @@ where
                     assert!(target_path.starts_with(&model_dir_path));
 
                     // Get the symlink target
-                    let symlink_target = std::path::PathBuf::from(
-                        fs.read_link(&filepath).await.unwrap().to_string(),
-                    );
-                    assert!(symlink_target.is_relative());
+                    let symlink_target = fs
+                        .read_link(&filepath)
+                        .await
+                        .unwrap()
+                        .to_path(&model_dir_path)
+                        .clean();
+                    assert!(symlink_target.starts_with(&model_dir_path));
 
                     // Create the dirs containing the symlink
                     tokio::fs::create_dir_all(target_path.parent().unwrap())
@@ -141,6 +144,7 @@ where
                         .unwrap();
 
                     // Create the symlink
+                    // TODO: do we want to convert it to a relative symlink instead of an absolute one?
                     tokio::fs::symlink(symlink_target, target_path)
                         .await
                         .unwrap();

--- a/source/carton/src/carton.rs
+++ b/source/carton/src/carton.rs
@@ -177,8 +177,11 @@ impl Carton {
 
         // Create a localfs with the new root
         // TODO: don't unwrap this one because it may fail if the runner returned an invalid path
-        let localfs =
-            Arc::new(lunchbox::LocalFS::with_base_dir(model_dir_path.to_string()).unwrap());
+        let localfs = Arc::new(
+            lunchbox::LocalFS::with_base_dir(model_dir_path.to_string())
+                .await
+                .unwrap(),
+        );
 
         // Ask the runner to load the model it just packed
         let info_with_extras = CartonInfoWithExtras {

--- a/source/carton/src/load.rs
+++ b/source/carton/src/load.rs
@@ -72,7 +72,7 @@ async fn fetch(url: &str, opts: LoadOpts, skip_runner: bool) -> ReturnType {
                 // This is a local directory (or a symlink to one)
                 // Skip directly to step 3
                 maybe_resolve_links(
-                    &Arc::new(lunchbox::LocalFS::with_base_dir(path.0).unwrap()),
+                    &Arc::new(lunchbox::LocalFS::with_base_dir(path.0).await.unwrap()),
                     opts,
                     skip_runner,
                 )

--- a/source/carton/src/overlayfs.rs
+++ b/source/carton/src/overlayfs.rs
@@ -153,10 +153,8 @@ where
             }
 
             // Otherwise, update the path and continue looping
-            let target = f.unwrap();
-
-            // Relative to the parent dir
-            path = path.parent().unwrap().join(target);
+            // (the result of `read_link` must be relative to the FS root so this is okay)
+            path = f.unwrap();
         }
     }
 


### PR DESCRIPTION
The paths returned by `read_link` in Lunchbox are now always absolute paths (i.e. relative to the filesystem root).

This PR updates `OverlayFS` to handle this. It also updates the loader in `carton-runner-py` and tests to ensure that symlinks work correctly.

See https://github.com/VivekPanyam/lunchbox/pull/12 and https://github.com/VivekPanyam/ZipFS/pull/2 for more details.

### Test plan

Updated a test in `carton-runner-py` to do more in-depth testing of symlinks within python models.