### PR TITLE
Initial implementation of streaming inference responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 
 [[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,7 +189,7 @@ dependencies = [
 [[package]]
 name = "async_zip"
 version = "0.0.15"
-source = "git+https://github.com/VivekPanyam/rs-async-zip.git?branch=fix_zip64#a4f1dc7b438f8ecd6092090df03bab31b69836ab"
+source = "git+https://github.com/VivekPanyam/rs-async-zip.git?branch=fix_zip64#fdce4981a54aa80e3e02ab22b4b800f50c8967bd"
 dependencies = [
  "async-compression 0.4.2",
  "chrono",
@@ -384,6 +395,7 @@ dependencies = [
 name = "carton"
 version = "0.1.0"
 dependencies = [
+ "async-stream",
  "async-trait",
  "bytes",
  "carton-macros",
@@ -487,11 +499,13 @@ name = "carton-runner-interface"
 version = "0.0.1"
 dependencies = [
  "anywhere",
+ "async-stream",
  "bincode",
  "carton-macros",
  "clap 4.1.1",
  "criterion",
  "dashmap",
+ "futures",
  "js-sys",
  "libc",
  "log",
@@ -552,6 +566,7 @@ dependencies = [
 name = "carton-runner-py"
 version = "0.0.1"
 dependencies = [
+ "async-stream",
  "bytes",
  "bytesize",
  "carton",
@@ -563,6 +578,8 @@ dependencies = [
  "escargot",
  "findshlibs",
  "flate2",
+ "futures",
+ "futures-util",
  "lazy_static",
  "libc",
  "log",
@@ -822,6 +839,15 @@ checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
  "termcolor",
  "unicode-width",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62ec6771ecfa0762d24683ee5a32ad78487a3d3afdc0fb8cae19d2c5deb50b7c"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1206,6 +1232,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "fastrand"
@@ -2320,6 +2352,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3564762e37035cfc486228e10b0528460fa026d681b5763873c693aa0d5c260"
 dependencies = [
+ "async-channel",
  "futures",
  "once_cell",
  "pin-project-lite",

--- a/source/carton-runner-interface/Cargo.toml
+++ b/source/carton-runner-interface/Cargo.toml
@@ -21,6 +21,8 @@ log = { version = "0.4", features = ["serde"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 tracing-chrome = "0.7"
+async-stream = "0.3"
+futures = "0.3"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 # This version is pinned because we don't want to accidentally break our transport

--- a/source/carton-runner-interface/src/do_not_modify/types.rs
+++ b/source/carton-runner-interface/src/do_not_modify/types.rs
@@ -29,6 +29,9 @@ pub(crate) struct RPCRequest {
 pub(crate) struct RPCResponse {
     pub id: RpcId,
 
+    // Whether this is the final response for this request
+    pub complete: bool,
+
     pub data: RPCResponseData,
 }
 
@@ -107,10 +110,16 @@ pub(crate) enum RPCRequestData {
 
     InferWithTensors {
         tensors: HashMap<String, Handle<Tensor>>,
+
+        // Do we support a streaming response
+        streaming: bool,
     },
 
     InferWithHandle {
         handle: SealHandle,
+
+        // Do we support a streaming response
+        streaming: bool,
     },
 }
 
@@ -144,6 +153,8 @@ pub(crate) enum RPCResponseData {
     LogMessage {
         record: LogRecord,
     },
+
+    Empty,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/source/carton-runner-noop/src/main.rs
+++ b/source/carton-runner-noop/src/main.rs
@@ -57,7 +57,7 @@ async fn main() {
                     .unwrap();
             }
 
-            RequestData::InferWithTensors { tensors } => {
+            RequestData::InferWithTensors { tensors, .. } => {
                 // Let's just return the input tensors for now
                 server
                     .send_response_for_request(req_id, ResponseData::Infer { tensors })
@@ -65,7 +65,7 @@ async fn main() {
                     .unwrap();
             }
 
-            RequestData::InferWithHandle { handle } => {
+            RequestData::InferWithHandle { handle, .. } => {
                 // TODO: return an error instead of using unwrap
                 let tensors = sealed_tensors.remove(&handle).unwrap();
 

--- a/source/carton-runner-py/Cargo.toml
+++ b/source/carton-runner-py/Cargo.toml
@@ -9,7 +9,7 @@ carton-runner-interface = { path = "../carton-runner-interface" }
 carton-utils = { path = "../carton-utils" }
 tokio = { version = "1", features = ["full"] }
 pyo3 = { version = "0.18"}
-pyo3-asyncio = { version = "0.18", features = ["attributes", "tokio-runtime"] }
+pyo3-asyncio = { version = "0.18", features = ["attributes", "tokio-runtime", "unstable-streams"] }
 numpy = "0.18"
 ndarray = { version = "0.15" }
 lazy_static = "1.4.0"
@@ -28,6 +28,9 @@ bytesize = {version = "1.1.0"}
 findshlibs = "0.10.2"
 carton-utils-py = {path = "../carton-utils-py"}
 tracing = "0.1"
+futures = "0.3"
+async-stream = "0.3"
+futures-util = "0.3"
 
 # Used by the `build_releases` binary
 semver = {version = "1.0.16"}

--- a/source/carton-runner-rust-bert/src/main.rs
+++ b/source/carton-runner-rust-bert/src/main.rs
@@ -98,7 +98,7 @@ async fn main() {
 
                 seal_counter += 1;
             }
-            RequestData::InferWithTensors { tensors } => {
+            RequestData::InferWithTensors { tensors, .. } => {
                 // TODO: error handling
                 let result = model.as_ref().map(|m| m.infer(tensors));
 
@@ -112,7 +112,7 @@ async fn main() {
                     .await
                     .unwrap();
             }
-            RequestData::InferWithHandle { handle } => {
+            RequestData::InferWithHandle { handle, .. } => {
                 // TODO: error handling
                 let result = sealed
                     .remove(&handle.get())

--- a/source/carton-runner-torch/src/main.rs
+++ b/source/carton-runner-torch/src/main.rs
@@ -104,7 +104,7 @@ async fn main() {
                 seal_counter += 1
             }
 
-            RequestData::InferWithTensors { tensors } => {
+            RequestData::InferWithTensors { tensors, .. } => {
                 // TODO: error handling
                 let m = model.as_ref().unwrap().clone();
                 let out = tokio::task::spawn_blocking(move || infer(m, tensors, device))
@@ -117,7 +117,7 @@ async fn main() {
                     .unwrap();
             }
 
-            RequestData::InferWithHandle { handle } => {
+            RequestData::InferWithHandle { handle, .. } => {
                 // TODO: error handling
                 let tensors = sealed_tensors.remove(&handle.get()).unwrap();
                 let m = model.as_ref().unwrap().clone();

--- a/source/carton/Cargo.toml
+++ b/source/carton/Cargo.toml
@@ -35,6 +35,7 @@ dashmap = "5.4.0"
 log = "0.4"
 pathdiff = "0.2.1"
 tokio-stream = "0.1"
+async-stream = "0.3"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 dlopen = "0.1"

--- a/source/carton/src/types.rs
+++ b/source/carton/src/types.rs
@@ -245,6 +245,20 @@ for_each_carton_type! {
     }
 }
 
+for_each_carton_type! {
+    impl<Storage: TensorStorage, Storage2: TensorStorage> PartialEq<Tensor<Storage2>> for Tensor<Storage> {
+        fn eq(&self, other: &Tensor<Storage2>) -> bool {
+            match (self, other) {
+                $(
+                    (Self::$CartonType(me), Tensor::<Storage2>::$CartonType(other))  => me.view() == other.view(),
+                )*
+                (Self::NestedTensor(me), Tensor::<Storage2>::NestedTensor(other)) => std::iter::zip(me, other).map(|(a, b)| a == b).all(|v| v),
+                _ => false,
+            }
+        }
+    }
+}
+
 pub trait TensorStorage {
     /// Storage for each tensor type
     type TypedStorage<T>: TypedStorage<T> + MaybeSend + MaybeSync


### PR DESCRIPTION
This PR implements changes in the runner interface needed for streaming inference responses. This lets an `infer` call return multiple tensors over the course of execution.

Since this is a breaking change in the wire protocol, this is landing before Carton is open-sourced. (The alternative of bumping the runner version and maintaining backwards compatibility doesn't really make sense if I'm the only one with old runners installed)

This PR also implements basic support and tests for this in the Python runner, but doesn't update the docs yet.

Python models should be able to make `infer_with_tensors` an async function now and yield dictionaries multiple times instead of just returning one. This'll be added to the docs after more in-depth testing.

For example,

```python
class Model:
    # ...
    def infer_with_tensors(self, tensors):
            return {
                "a": np.zeros(4, dtype=np.float32)
            }
```

can be modified to return intermediate results:

```python
class Model:
    # ...
    async def infer_with_tensors(self, tensors):
        for i in range(5):
            yield {
                "a": np.zeros(i, dtype=np.float32)
            }
```