### PR TITLE
Update ZipFS dependency and remove patches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,9 +187,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "async_zip"
-version = "0.0.15"
-source = "git+https://github.com/VivekPanyam/rs-async-zip.git?branch=fix_zip64#fdce4981a54aa80e3e02ab22b4b800f50c8967bd"
+name = "async_zip2"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "201aabc95456ea2a0fa400f8772ae3af09b1ecd7001a57e1a48089daa6c1bd74"
 dependencies = [
  "async-compression 0.4.2",
  "chrono",
@@ -538,7 +539,7 @@ dependencies = [
 name = "carton-runner-packager"
 version = "0.0.1"
 dependencies = [
- "async_zip 0.0.11",
+ "async_zip",
  "base64 0.21.0",
  "carton-utils",
  "chrono",
@@ -656,7 +657,7 @@ dependencies = [
 name = "carton-utils"
 version = "0.0.1"
 dependencies = [
- "async_zip 0.0.11",
+ "async_zip",
  "bytes",
  "flate2",
  "futures",
@@ -1815,8 +1816,9 @@ dependencies = [
 
 [[package]]
 name = "lunchbox"
-version = "0.1.3"
-source = "git+https://github.com/VivekPanyam/lunchbox.git?branch=main#375d35f887bc2ab86af25e9228bcb04bd8772310"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09eda175c38af45f3884135536bd707777ae506c5fe0efe4640504b19757deaf"
 dependencies = [
  "async-trait",
  "path-clean",
@@ -3954,11 +3956,12 @@ dependencies = [
 
 [[package]]
 name = "zipfs"
-version = "0.0.1"
-source = "git+https://github.com/VivekPanyam/ZipFS.git?branch=read_full#0c27172f53c86ac6cd4a5bd57174a19bc5e4a7e7"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5a98b9edc12b0a2b18f41e8929438239c0aadd7505542d5b05094f263bdb4e7"
 dependencies = [
  "async-trait",
- "async_zip 0.0.15",
+ "async_zip2",
  "lunchbox",
  "path-clean",
  "pin-project",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,5 @@ lto = "thin"
 debug = true
 
 [patch.crates-io]
-# Temporary patch while we're waiting for an upstream merge + release in async_zip
-zipfs = { git = "https://github.com/VivekPanyam/ZipFS.git", branch = "read_full" }
-async_zip = { git = "https://github.com/VivekPanyam/rs-async-zip.git", branch = "fix_zip64" }
-lunchbox = { git = "https://github.com/VivekPanyam/lunchbox.git", branch = "main" }
+# Temporary patch while we're waiting for an upstream merge + release
 torch-sys = { git = "https://github.com/VivekPanyam/tch-rs.git", branch = "fix_dict_bug" }

--- a/source/carton/Cargo.toml
+++ b/source/carton/Cargo.toml
@@ -20,7 +20,7 @@ target-lexicon = {version = "0.12.7", features = ["serde_support"]}
 lazy_static = "1.4.0"
 reqwest = { version = "0.11", features = ["json", "rustls-tls", "stream"], default-features = false }
 bytes = "1.3.0"
-zipfs = "0.0.1"
+zipfs = "0.0.2"
 url = "2.3.1"
 async-trait = "0.1"
 runner_interface_v1 = { package = "carton-runner-interface", path = "../carton-runner-interface" }


### PR DESCRIPTION
Updating `ZipFS` to 0.0.2 lets us remove patches for `lunchbox`, `zipfs`, and `async_zip`. Removing these patches also means we can now push the core library to crates.io