### PR TITLE
Update crate metadata, docs, and publish to crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,7 +73,7 @@ checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
 
 [[package]]
 name = "anywhere"
-version = "0.0.0"
+version = "0.0.1"
 dependencies = [
  "async-trait",
  "bincode",
@@ -394,7 +394,7 @@ dependencies = [
 
 [[package]]
 name = "carton"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -488,7 +488,7 @@ dependencies = [
 
 [[package]]
 name = "carton-macros"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",

--- a/docs/website/components/code.tsx
+++ b/docs/website/components/code.tsx
@@ -24,6 +24,7 @@ import Prism from "prism-react-renderer/prism";
 
 
 require("prismjs/components/prism-rust")
+require("prismjs/components/prism-toml")
 
 // From https://github.com/LekoArts/gatsby-themes/blob/main/packages/themes-utils/src/index.ts
 // (MIT licensed)
@@ -60,6 +61,7 @@ const LANGUAGE_TAGS = {
     "js": {"bg": "bg-emerald-500", tag: "js"},
     "rust": {"bg": "bg-violet-500", tag: "rust"},
     "json": { "bg": "bg-orange-500", tag: "json" },
+    "toml": { "bg": "bg-orange-500", tag: "toml" },
 }
 
 const Code = ({

--- a/docs/website/pages/docs/loading.mdx
+++ b/docs/website/pages/docs/loading.mdx
@@ -35,9 +35,13 @@ asyncio.run(main())
 
 ```rust forLang='rust'
 use carton::Carton;
-use carton::types::LoadOpts;
+use carton::types::{LoadOpts, Tensor, GenericStorage};
 
+#[tokio::main]
 async fn main() {
+    // See the logging section in the quickstart guide
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
     // Load the model
     let model = Carton::load(
         "https://carton.pub/google-research/bert-base-uncased",
@@ -55,12 +59,27 @@ async fn main() {
 
     // Run inference
     let out = model
-        .infer([("input_sequences", Tensor::<GenericStorage>::String(arr))])
+        .infer([("input", Tensor::<GenericStorage>::String(arr))])
         .await
         .unwrap();
     println!("{out:?}");
 }
 ```
+
+<LanguageSwitch>
+<LanguageItem forLang='rust'>
+
+To run the above, you'll also need these dependencies in your `Cargo.toml` file:
+
+```toml
+[dependencies]
+tokio = {version = "1", features = ["macros", "rt-multi-thread"]}
+ndarray = "0.15"
+env_logger = "0.10"
+```
+
+</LanguageItem>
+</LanguageSwitch>
 
 Carton loads the model (caching it locally if necessary).
 

--- a/docs/website/pages/quickstart.mdx
+++ b/docs/website/pages/quickstart.mdx
@@ -21,7 +21,7 @@ npm install @cartonml/wasm@next
 ```
 
 ```bash linePrompt='$' forLang='rust'
-cargo add --git https://github.com/VivekPanyam/carton carton
+cargo add carton
 ```
 
 <LanguageSwitch>
@@ -61,9 +61,13 @@ asyncio.run(main())
 
 ```rust forLang='rust'
 use carton::Carton;
-use carton::types::LoadOpts;
+use carton::types::{LoadOpts, Tensor, GenericStorage};
 
+#[tokio::main]
 async fn main() {
+    // See the logging section below
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
     // Load the model
     let model = Carton::load(
         "https://carton.pub/google-research/bert-base-uncased",
@@ -81,12 +85,27 @@ async fn main() {
 
     // Run inference
     let out = model
-        .infer([("input_sequences", Tensor::<GenericStorage>::String(arr))])
+        .infer([("input", Tensor::<GenericStorage>::String(arr))])
         .await
         .unwrap();
     println!("{out:?}");
 }
 ```
+
+<LanguageSwitch>
+<LanguageItem forLang='rust'>
+
+To run the above, you'll also need these dependencies in your `Cargo.toml` file:
+
+```toml
+[dependencies]
+tokio = {version = "1", features = ["macros", "rt-multi-thread"]}
+ndarray = "0.15"
+env_logger = "0.10"
+```
+
+</LanguageItem>
+</LanguageSwitch>
 
 See the ["Loading a model"](/docs/loading) docs for more details.
 

--- a/docs/website/styles/prism_style.css
+++ b/docs/website/styles/prism_style.css
@@ -75,3 +75,8 @@ pre {
 .token.inserted.prefix {
     @apply text-emerald-200 text-opacity-75 select-none !important;
 }
+
+/* For toml */
+.token.table {
+    display: inline;
+}

--- a/source/anywhere/Cargo.toml
+++ b/source/anywhere/Cargo.toml
@@ -1,8 +1,13 @@
 [package]
 name = "anywhere"
-version = "0.0.0"
+version = "0.0.1"
 edition = "2021"
-publish = false
+authors = ["Vivek Panyam <hello@vivekpanyam.com>"]
+description = "Serve Lunchbox filesystems over a transport."
+license = "Apache-2.0"
+repository = "https://github.com/VivekPanyam/carton"
+keywords = []
+categories = []
 
 [dependencies]
 tokio = { version = "1", features = ["io-util", "sync", "rt"] }
@@ -14,7 +19,7 @@ paste = "1"
 pin-project = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"
-relative-path = { features = ["serde"] }
+relative-path = { version = "1.7", features = ["serde"] }
 bincode = "1.3.3"
 lazy_static = "1.4.0"
 tracing = "0.1"

--- a/source/carton-macros/Cargo.toml
+++ b/source/carton-macros/Cargo.toml
@@ -1,8 +1,13 @@
 [package]
 name = "carton-macros"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
-publish = false
+authors = ["Vivek Panyam <hello@vivekpanyam.com>"]
+description = "Macros used by `carton`"
+license = "Apache-2.0"
+repository = "https://github.com/VivekPanyam/carton"
+keywords = []
+categories = []
 
 [lib]
 proc-macro = true

--- a/source/carton-runner-interface/Cargo.toml
+++ b/source/carton-runner-interface/Cargo.toml
@@ -2,17 +2,22 @@
 name = "carton-runner-interface"
 version = "0.0.1"
 edition = "2021"
-publish = false
+authors = ["Vivek Panyam <hello@vivekpanyam.com>"]
+description = "The runner interface for `carton`"
+license = "Apache-2.0"
+repository = "https://github.com/VivekPanyam/carton"
+keywords = []
+categories = []
 
 [dependencies]
 tempfile = "3.3.0"
 bincode = "1.3.3"
 serde = { version = "1.0", features = ["derive"] }
-tokio = { version = "1", features = ["io-util", "sync", "rt"] }
+tokio = { version = "1", features = ["io-util", "sync", "rt", "time"] }
 dashmap = "5.4.0"
-carton-macros = { path = "../carton-macros" }
+carton-macros = { path = "../carton-macros", version = "0.0.1"}
 ndarray = { version = "0.15", features = ["serde"] }
-anywhere = { path = "../anywhere" }
+anywhere = { path = "../anywhere", version = "0.0.1"}
 lunchbox = { version = "0.1", features = ["serde"], default-features = false }
 semver = {version = "1.0.16", features = ["serde"]}
 once_cell = "1.17.0"

--- a/source/carton-runner-packager/Cargo.toml
+++ b/source/carton-runner-packager/Cargo.toml
@@ -2,10 +2,15 @@
 name = "carton-runner-packager"
 version = "0.0.1"
 edition = "2021"
-publish = false
+authors = ["Vivek Panyam <hello@vivekpanyam.com>"]
+description = "Runner packaging utils used by `carton`"
+license = "Apache-2.0"
+repository = "https://github.com/VivekPanyam/carton"
+keywords = []
+categories = []
 
 [dependencies]
-carton-utils = { path = "../carton-utils" }
+carton-utils = { path = "../carton-utils", version = "0.0.1"}
 tokio = { version = "1", features = ["full"] }
 toml = "0.5"
 serde = { version = "1.0", features = ["derive"] }

--- a/source/carton-utils/Cargo.toml
+++ b/source/carton-utils/Cargo.toml
@@ -2,7 +2,12 @@
 name = "carton-utils"
 version = "0.0.1"
 edition = "2021"
-publish = false
+authors = ["Vivek Panyam <hello@vivekpanyam.com>"]
+description = "Utilities used by `carton`"
+license = "Apache-2.0"
+repository = "https://github.com/VivekPanyam/carton"
+keywords = []
+categories = []
 
 [dependencies]
 tokio = { version = "1", features = [] }

--- a/source/carton/Cargo.toml
+++ b/source/carton/Cargo.toml
@@ -1,8 +1,13 @@
 [package]
 name = "carton"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
-publish = false
+authors = ["Vivek Panyam <hello@vivekpanyam.com>"]
+description = "Run any ML model from any programming language."
+license = "Apache-2.0"
+repository = "https://github.com/VivekPanyam/carton"
+keywords = []
+categories = []
 
 # Ignore all test_data/ folders
 exclude = ["test_data/"]
@@ -12,7 +17,7 @@ serde = { version = "1.0", features = ["derive"] }
 ndarray = { version = "0.15", features = ["serde"] }
 tokio = { version = "1", features = ["rt"] }
 tempfile = "3.3.0"
-carton-macros = { path = "../carton-macros" }
+carton-macros = { path = "../carton-macros", version = "0.0.1"}
 chrono = {version = "0.4.23", features = ["serde"]}
 toml = "0.5"
 semver = {version = "1.0.16", features = ["serde"]}
@@ -23,7 +28,7 @@ bytes = "1.3.0"
 zipfs = "0.0.2"
 url = "2.3.1"
 async-trait = "0.1"
-runner_interface_v1 = { package = "carton-runner-interface", path = "../carton-runner-interface" }
+runner_interface_v1 = { package = "carton-runner-interface", path = "../carton-runner-interface", version = "0.0.1"}
 thiserror = "1"
 sha2 = "0.10.6"
 walkdir = "2.3.2"
@@ -42,9 +47,9 @@ dlopen = "0.1"
 dlopen_derive = "0.1"
 uuid = "1.3"
 lunchbox = { version = "0.1", features = ["serde", "localfs"]}
-carton-runner-packager = { path = "../carton-runner-packager" }
+carton-runner-packager = { path = "../carton-runner-packager", version = "0.0.1"}
 zip = {version = "0.6", features = ["zstd"]}
-carton-utils = { path = "../carton-utils" }
+carton-utils = { path = "../carton-utils", version = "0.0.1"}
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 lunchbox = { version = "0.1", features = ["serde"]}

--- a/source/carton/README.md
+++ b/source/carton/README.md
@@ -1,0 +1,21 @@
+# Carton
+
+Carton is a library that lets you run any machine learning (ML) model from any programming language*.
+
+It wraps existing models and provides a uniform interface for your application to use regardless of the framework the underlying model was implemented in.
+
+See https://carton.run for an overview of how it works and how to get started.
+
+# Getting started
+
+See the quickstart guide at https://carton.run/quickstart
+
+# Model Registry
+
+We have a model registry containing several popular open-source models.
+
+Explore the registry at https://carton.pub and check out the [quickstart guide](https://carton.run/quickstart).
+
+# Docs
+
+See the documentation at https://carton.run/docs


### PR DESCRIPTION
This PR contains `Cargo.toml` metadata changes made in order to publish to crates.io.

It also updates the quickstart guide to use the newly published crate (and fixes the quickstart example).