### PR TITLE
Add an `Allocatable` trait to the runner interface

### DIFF
--- a/source/carton-runner-interface/src/do_not_modify/alloc.rs
+++ b/source/carton-runner-interface/src/do_not_modify/alloc.rs
@@ -31,8 +31,17 @@ pub trait AsPtr<T> {
     fn as_mut_ptr(&mut self) -> *mut T;
 }
 
-pub trait TypedAlloc<T> {
-    type Output: AsPtr<T>;
+pub trait Allocator {
+    type Output;
+}
 
+pub trait TypedAlloc<T>: Allocator
+where
+    Self::Output: AsPtr<T>,
+{
     fn alloc(&self, numel: usize) -> Self::Output;
+}
+
+pub trait AllocatableBy<A: Allocator>: Sized {
+    fn alloc(allocator: &A, numel: usize) -> A::Output;
 }

--- a/source/carton-runner-interface/src/do_not_modify/types.rs
+++ b/source/carton-runner-interface/src/do_not_modify/types.rs
@@ -12,11 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub use carton_macros::for_each_carton_type;
+pub use carton_macros::{for_each_carton_type, for_each_numeric_carton_type};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-use super::{alloc_inline::InlineTensorStorage, comms::Comms};
+use super::{
+    alloc::AllocatableBy,
+    alloc_inline::{InlineAllocator, InlineTensorStorage},
+    comms::Comms,
+};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct RPCRequest {
@@ -246,6 +250,9 @@ for_each_carton_type! {
 }
 
 pub type TensorStorage<T> = super::storage::TensorStorage<T, InlineTensorStorage>;
+
+pub trait Allocatable: AllocatableBy<InlineAllocator> {}
+impl<T> Allocatable for T where T: AllocatableBy<InlineAllocator> {}
 
 for_each_carton_type! {
     $(

--- a/source/carton-runner-interface/src/runner.rs
+++ b/source/carton-runner-interface/src/runner.rs
@@ -17,12 +17,8 @@ use std::{collections::HashMap, sync::Arc};
 use crate::{
     client::Client,
     do_not_modify::comms::OwnedComms,
-    do_not_modify::{
-        alloc::TypedAlloc,
-        alloc_inline::{InlineAllocator, InlineTensorStorage},
-        types::{Device, RPCRequestData, RPCResponseData, SealHandle, Tensor},
-    },
-    types::{Handle, RunnerOpt, TensorStorage},
+    do_not_modify::types::{Device, RPCRequestData, RPCResponseData, SealHandle, Tensor},
+    types::{Allocatable, Handle, RunnerOpt, TensorStorage},
 };
 
 use futures::Stream;
@@ -299,9 +295,11 @@ impl Runner {
         }
     }
 
-    pub fn alloc_tensor<T: Clone + Default>(&self, shape: Vec<u64>) -> Result<Tensor, String>
+    pub fn alloc_tensor<T: Clone + Default + Allocatable>(
+        &self,
+        shape: Vec<u64>,
+    ) -> Result<Tensor, String>
     where
-        InlineAllocator: TypedAlloc<T, Output = InlineTensorStorage>,
         Tensor: From<TensorStorage<T>>,
     {
         Ok(TensorStorage::new(shape).into())

--- a/source/carton-runner-wasm/Cargo.toml
+++ b/source/carton-runner-wasm/Cargo.toml
@@ -7,7 +7,6 @@ publish = false
 exclude = ["tests/test_model", "carton-wasm-interface"]
 
 [dependencies]
-carton = { path = "../carton" }
 carton-runner-interface = { path = "../carton-runner-interface" }
 color-eyre = "0.6.2"
 lunchbox = { version = "0.1", default-features = false }
@@ -29,3 +28,4 @@ semver = "1.0.20"
 escargot = "0.5.8"
 paste = "1.0.14"
 tempfile = "3.8.0"
+carton = { path = "../carton" }

--- a/source/carton-runner-wasm/src/types.rs
+++ b/source/carton-runner-wasm/src/types.rs
@@ -1,8 +1,9 @@
 use color_eyre::eyre::{ensure, eyre};
 use color_eyre::{Report, Result};
 
-use carton::types::for_each_numeric_carton_type;
-use carton_runner_interface::types::{Tensor as CartonTensor, TensorStorage as CartonStorage};
+use carton_runner_interface::types::{
+    for_each_numeric_carton_type, Tensor as CartonTensor, TensorStorage as CartonStorage,
+};
 
 use crate::component::{Dtype, Tensor as WasmTensor, TensorNumeric, TensorString};
 


### PR DESCRIPTION
This PR adds an `Allocatable` trait to the runner interface. This generally makes it cleaner to write generic functions over Carton types without needing to reference implementation details in trait bounds (e.g. `where InlineAllocator: TypedAlloc<T, Output = InlineTensorStorage>`).

Note: this PR does touch files inside `do_not_modify`, but it does so in a way that does not affect the wire protocol.