### PR TITLE
Make the C++ interface easier to use

### DIFF
--- a/docs/website/pages/docs/loading.mdx
+++ b/docs/website/pages/docs/loading.mdx
@@ -307,7 +307,7 @@ int main()
     // Create an input tensor
     uint64_t shape[]{1};
     auto tensor = carton::Tensor(carton::DataType::kString, shape);
-    tensor.set_string(0, "Today is a good [MASK].");
+    tensor.at<std::string_view>(0) = "Today is a good [MASK].";
 
     // Create a map of inputs
     std::unordered_map<std::string, carton::Tensor> inputs;
@@ -322,7 +322,7 @@ int main()
 
     const auto scores_data = static_cast<const float *>(scores.data());
 
-    std::cout << "Got output token: " << tokens.get_string(0) << std::endl;
+    std::cout << "Got output token: " << tokens.at<std::string_view>(0) << std::endl;
     std::cout << "Got output scores: " << scores_data[0] << std::endl;
 }
 ```

--- a/docs/website/pages/quickstart.mdx
+++ b/docs/website/pages/quickstart.mdx
@@ -63,7 +63,7 @@ int main()
     // Create an input tensor
     uint64_t shape[]{1};
     auto tensor = carton::Tensor(carton::DataType::kString, shape);
-    tensor.set_string(0, "Today is a good [MASK].");
+    tensor.at<std::string_view>(0) = "Today is a good [MASK].";
 
     // Create a map of inputs
     std::unordered_map<std::string, carton::Tensor> inputs;
@@ -78,7 +78,7 @@ int main()
 
     const auto scores_data = static_cast<const float *>(scores.data());
 
-    std::cout << "Got output token: " << tokens.get_string(0) << std::endl;
+    std::cout << "Got output token: " << tokens.at<std::string_view>(0) << std::endl;
     std::cout << "Got output scores: " << scores_data[0] << std::endl;
 }
 ```

--- a/source/carton-bindings-cpp/tests/callback.cc
+++ b/source/carton-bindings-cpp/tests/callback.cc
@@ -32,10 +32,12 @@ void infer_callback(Result<TensorMap> infer_result, void *arg)
     const auto tokens = out.get_and_remove("tokens");
     const auto scores = out.get_and_remove("scores");
 
-    const auto scores_data = static_cast<const float *>(scores.data());
+    // Can use a template arg of `std::string` or `std::string_view`
+    std::cout << "Got output token: " << tokens.at<std::string>(0) << std::endl;
+    std::cout << "Got output scores: " << scores.at<float>(0) << std::endl;
 
-    std::cout << "Got output token: " << tokens.get_string(0) << std::endl;
-    std::cout << "Got output scores: " << scores_data[0] << std::endl;
+    assert(tokens.at<std::string_view>(0) == std::string_view("day"));
+    assert(std::abs(scores.at<float>(0) - 14.5513) < 0.0001);
 
     exit(0);
 }
@@ -47,7 +49,7 @@ void load_callback(Result<Carton> model_result, void *arg)
 
     uint64_t shape[]{1};
     auto tensor = Tensor(DataType::kString, shape);
-    tensor.set_string(0, "Today is a good [MASK].");
+    tensor.at<std::string_view>(0) = "Today is a good [MASK].";
 
     std::unordered_map<std::string, Tensor> inputs;
     inputs.insert(std::make_pair("input", std::move(tensor)));

--- a/source/carton-bindings-cpp/tests/future.cc
+++ b/source/carton-bindings-cpp/tests/future.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cassert>
 #include <iostream>
 
 #include "../src/carton.hh"
@@ -28,7 +29,9 @@ int main()
 
     uint64_t shape[]{1};
     auto tensor = Tensor(DataType::kString, shape);
-    tensor.set_string(0, "Today is a good [MASK].");
+
+    // Can use a template arg of `std::string` or `std::string_view`
+    tensor.at<std::string>(0) = "Today is a good [MASK].";
 
     std::unordered_map<std::string, Tensor> inputs;
     inputs.insert(std::make_pair("input", std::move(tensor)));
@@ -41,6 +44,9 @@ int main()
 
     const auto scores_data = static_cast<const float *>(scores.data());
 
-    std::cout << "Got output token: " << tokens.get_string(0) << std::endl;
+    std::cout << "Got output token: " << tokens.at<std::string_view>(0) << std::endl;
     std::cout << "Got output scores: " << scores_data[0] << std::endl;
+
+    assert(tokens.at<std::string_view>(0) == std::string_view("day"));
+    assert(std::abs(scores_data[0] - 14.5513) < 0.0001);
 }

--- a/source/carton-bindings-cpp/tests/notifier.cc
+++ b/source/carton-bindings-cpp/tests/notifier.cc
@@ -38,7 +38,7 @@ int main()
 
     uint64_t shape[]{1};
     auto tensor = Tensor(DataType::kString, shape);
-    tensor.set_string(0, "Today is a good [MASK].");
+    tensor.at<std::string_view>(0) = "Today is a good [MASK].";
 
     std::unordered_map<std::string, Tensor> inputs;
     inputs.insert(std::make_pair("input", std::move(tensor)));
@@ -56,6 +56,13 @@ int main()
 
     const auto scores_data = static_cast<const float *>(scores.data());
 
-    std::cout << "Got output token: " << tokens.get_string(0) << std::endl;
+    // If you're accessing a few elements, you can just use `.at`, but we'll use
+    // an accessor here for testing
+    const auto token_accessor = tokens.accessor<std::string_view, 1>();
+
+    std::cout << "Got output token: " << token_accessor[0] << std::endl;
     std::cout << "Got output scores: " << scores_data[0] << std::endl;
+
+    assert(token_accessor[0] == std::string_view("day"));
+    assert(std::abs(scores_data[0] - 14.5513) < 0.0001);
 }


### PR DESCRIPTION
This PR adds a more convenient way to index into tensors from the C++ API.

Previously, a user would have to explicitly compute an offset based on the strides of a tensor and their desired index (or use an external library).

They would also have to use different methods for string tensors and numeric tensors (e.g. `get_string`/`set_string` for dealing with string tensors).

This PR provides an `at` method that lets users pass in an index and get an element. It also provides an `accessor` method that can be used when accessing several elements. These work for both string and numeric tensors.

Note: this is a breaking change for the following reasons:

* `get_string` and `set_string` in the C++ API are now private methods
* `carton_tensor_get_string`, `carton_tensor_set_string`, and `carton_tensor_set_string_with_strlen` from the C API now expect their `index` argument to take strides into account. This shouldn't have a practical impact as all our current ways of creating string tensors and exposing them via the C API create tensors with standard strides.